### PR TITLE
Phase 0 — Documentation & license hygiene (right-size governance, document licensing)

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -164,9 +164,9 @@ Each layer must stand on its own before moving forward.
 
 This approach favors long-term stability over short-term progress.
 
-### 4.6 Community Over Authority:
+### 4.6 Decisions Follow Evidence, Not Authority:
 
-No individual, organization, or sponsor has unilateral control over the technical direction of the project.
+Design decisions are justified on technical grounds — not seniority, affiliation, or assertion.
 
 Decisions are made based on:
 
@@ -174,7 +174,7 @@ Decisions are made based on:
 2. Evidence  
 3. Reproducibility
 
-Authority in OMI is earned through contribution, not position.
+A decision stands because it can be defended and reproduced, not because of who made it.
 
 ### 4.7 Transparency Includes Limitations:
 
@@ -403,9 +403,9 @@ If OMI allows others to learn, to experiment, and to extend the work without per
 
 ## 
 
-## 9\. Community, Governance, and Contribution Model:
+## 9\. Governance and Contribution Model:
 
-OMI is a community-based engineering project. Its long-term success hangs on explicit expectations regarding participation, decision-making, and responsibility. This section defines how the project is organized and how contributors interact. OMI doesn't want to enforce control; governance in OMI is continuity.
+OMI is currently developed and maintained by a single author, in the open. It is built so that others can read, reproduce, challenge, and extend the work — not as a multi-stakeholder consortium. This section describes how the project is organized and how contributors can take part. "Governance" here means continuity and transparency — decisions recorded and justified so they can be audited — not committees or control.
 
 ### 9.1 Who Can Contribute:
 
@@ -417,11 +417,11 @@ OMI does not just depend on generating code and drawing schematics. Valid contri
 
 ### 9.3 Decision-Making Process:
 
-Technical decisions in OMI are made in public and are justified on technical grounds. Discussions, proposals, and assessments take place in forums linked to project developments. At the same time, decisions are based on the evidence available, reproducibility, and alignment with the project's projected scope and principles. Where disagreements exist, those approaches should be preferred because they minimize risk, add clarity, or keep openness. No one contributor has full control over the technical direction of the project.
+Technical decisions are made on the record and justified on technical grounds. They are based on the available evidence, reproducibility, and alignment with the project's scope and principles. Where trade-offs exist, the option that minimizes risk, adds clarity, or preserves openness is preferred. Decisions and their rationale are documented so they can be audited and revisited later.
 
-### 9.4 Maintainers and Stewardship:
+### 9.4 Maintenance:
 
-Maintainers & contributors responsible for reviewing contributions, integrating changes, and making sure everything is done consistently across multiple functions of the project. Maintainer roles are earned through continuous, well-substantiated contributions and can be revoked if responsibilities are left unfulfilled. The maintainers are stewards of the principles behind the project and not gatekeepers of participation.
+The project is presently maintained by its author, who reviews contributions for consistency, correctness, and alignment with the charter's principles and scope. As the project grows, maintenance can be shared with sustained contributors. Maintainers are stewards of the project's principles, not gatekeepers of participation.
 
 ### 9.5 Transparency and Accountability:
 
@@ -429,7 +429,7 @@ All project work is in public view. This extends to design discussions, reviews,
 
 ### 9.6 Code of Conduct:
 
-OMI expects all participants to participate respectfully and professionally. Technical disagreement is encouraged. Personal attacks, harassment, and exclusionary behavior are not accepted. The project emphasizes that clarity, honesty, and mutual respect are of core value to effective engineering collaboration.
+OMI expects all participants to participate respectfully and professionally. Technical disagreement is encouraged. Personal attacks, harassment, and exclusionary behavior are not accepted. The project emphasizes that clarity, honesty, and mutual respect are of core value to effective engineering collaboration. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ## 10\. Risks, Limitations, and Reality Check:
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,9 +46,7 @@ spaces.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the project maintainer at **[GitHub Issues](https://github.com/The-Open-Memory-Initiative-OMI/omi/issues)** or by contacting the
-repository owner directly through GitHub.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the project maintainer at sensoymertefe@gmail.com . Please do not use public GitHub Issues for sensitive reports.
 
 All complaints will be reviewed and investigated promptly and fairly. The project
 team is obligated to maintain confidentiality with regard to the reporter of an

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in the
-Open Memory Initiative (OMI) community a harassment-free experience for everyone, regardless of age, body
+the Open Memory Initiative (OMI) community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
 nationality, personal appearance, race, caste, color, religion, or sexual

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in the
-World Monitor community a harassment-free experience for everyone, regardless of age, body
+Open Memory Initiative (OMI) community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
 nationality, personal appearance, race, caste, color, religion, or sexual
@@ -47,7 +47,7 @@ spaces.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the project maintainer at **[GitHub Issues](https://github.com/koala73/worldmonitor/issues)** or by contacting the
+reported to the project maintainer at **[GitHub Issues](https://github.com/The-Open-Memory-Initiative-OMI/omi/issues)** or by contacting the
 repository owner directly through GitHub.
 
 All complaints will be reviewed and investigated promptly and fairly. The project

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,8 @@ All contributors are expected to interact respectfully and professionally.
 
 Technical disagreement is encouraged. Personal attacks, harassment, or exclusionary behavior are not tolerated.
 
+The full text is in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
 ---
 
 ## **Questions**

--- a/PHASE0_CLEANUP_PROPOSAL.md
+++ b/PHASE0_CLEANUP_PROPOSAL.md
@@ -141,7 +141,7 @@ by removing files — consistent with the brief's "right-size, do not gut" and "
 > Confirm the split, or tell me to unify and I'll amend.
 
 Secondary flag within the split: the docs license is currently **CC-BY-SA-4.0** (ShareAlike /
-copyleft). The brief floated **CC-BY-4.0** (permissive). Kept SA to avoid an unilateral copyleft
+copyleft). The brief floated **CC-BY-4.0** (permissive). Kept SA to avoid a unilateral copyleft
 change — say the word to switch.
 
 ---

--- a/PHASE0_CLEANUP_PROPOSAL.md
+++ b/PHASE0_CLEANUP_PROPOSAL.md
@@ -1,0 +1,167 @@
+# Phase 0 — Documentation & License Hygiene: Cleanup Proposal
+
+**Branch:** `phase0-doc-hygiene`
+**Status:** Proposed (for review via PR; `main` untouched, nothing merged)
+**Scope owner:** Phase 0 only — documentation/governance/license hygiene. No engineering
+artifacts, no status/claims language, no rename/rebrand. Those belong to later phases (P1–P7).
+
+---
+
+## 1. Problem / Motivation
+
+An independent audit found that this repository — a **single-author DDR4 UDIMM reference-design
+study** with zero external contributors — was carrying **consortium-grade governance** (a ~500-line
+charter with a multi-maintainer stewardship model, decision-making "forums," and "community over
+authority" framing) and **three separate LICENSE files** whose split was assumed to be undocumented.
+That weight is mismatched to a solo educational study. Phase 0 right-sizes the governance prose and
+makes the licensing intent explicit **without** stripping the repo's professional, credible face
+(it is referenced from the author's CV, website, and LinkedIn).
+
+A read-only inventory pass (three parallel sub-agents: licenses, governance/meta docs, reference
+graph) was run before any change. Its findings **refined two of the audit's assumptions**:
+
+1. **The license split is already documented**, not orphaned. The README already maps each license
+   to a content type (lines ~175–187) and seven docs already carry
+   `<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->` headers. All three license files are
+   **distinct** (MD5-confirmed) and **load-bearing** (each linked from the README). → The correct
+   action is to **document the split more clearly, not delete** any license. This matches the brief's
+   rule: *never blind-delete a license without proving nothing depends on it.*
+2. **The consortium theater is concentrated in `CHARTER.md`** (§4.6 and §9), so it can be
+   **right-sized in place** rather than by deleting files.
+
+The inventory also surfaced **one genuine defect** the audit had not named:
+`CODE_OF_CONDUCT.md` is a **mis-pasted Code of Conduct from an unrelated project** — it pledges to
+the "World Monitor community" and routes incident reports to `github.com/koala73/worldmonitor/issues`.
+This is a correctness bug (a foreign project's identity left in OMI's repo), not a rebrand of OMI,
+and it is fixed here.
+
+---
+
+## 2. Method (read-only inventory, then implement)
+
+Per the Phase 0 brief, **Step 1 was a read-only fan-out** — no files were changed while inventorying:
+
+- **Sub-agent A — Licenses:** found exactly **3** license files; identified each license from its
+  actual text; confirmed all three are distinct (no duplicates) and which content type each covers.
+- **Sub-agent B — Governance/meta docs:** enumerated every governance/meta doc with line counts and
+  flagged the consortium-theater language (concentrated in `CHARTER.md`).
+- **Sub-agent C — Reference graph:** grepped the whole repo for inbound references to separate
+  **load-bearing** files from **orphans**, and verified which README internal links are broken.
+
+The three results were cross-checked against each other before this proposal was written.
+
+---
+
+## 3. Decision table
+
+**Legend:** KEEP = leave as-is · KEEP+EDIT = keep the file, surgically right-size/correct it ·
+CONSOLIDATE = trim in place · DROP = delete · FLAG = leave unchanged this phase, raise for a later phase.
+
+### 3a. License files
+
+| File / path | License / role | Referenced by? | Action | Reason |
+|---|---|---|---|---|
+| `LICENSE` | CERN-OHL-S-2.0 — **hardware** (`design/**`) | README:180 (linked); covers KiCad/PCB artifacts | **KEEP** | Load-bearing, correct license for hardware. The brief explicitly keeps CERN-OHL-S-2.0 for hardware. |
+| `LICENSE-docs` | CC-BY-SA-4.0 — **prose docs** | README:182 (linked); SPDX headers in 7 docs | **KEEP** (flag SA) | Load-bearing; claimed by SPDX headers. Existing license is CC-BY-**SA**-4.0 (copyleft). The brief *suggested* CC-BY-4.0 (permissive); switching would **remove ShareAlike**, a substantive legal change, so it is **not** done unilaterally — see Open Question (§6). |
+| `LICENSE-software` | Apache-2.0 — **code** (Python tooling) | README:184 (linked) | **KEEP** | Load-bearing; matches the brief's recommendation (one permissive license for the scripts so they're cleanly reusable downstream). |
+
+**No license file is deleted.** All three are distinct and load-bearing; the reference graph
+contradicts the "orphaned license" hypothesis.
+
+### 3b. Governance / meta docs (root)
+
+| File / path | Role | Referenced by? | Action | Reason |
+|---|---|---|---|---|
+| `README.md` | Project front page | Entry point; links most docs | **KEEP+EDIT** | Add an explicit **Licensing** section mapping *license → directory*; add a Code of Conduct link. Broken nav links **flagged, not fixed** (see §5). No status/claims wording touched. |
+| `CHARTER.md` (508 lines) | Charter: purpose, scope, principles, governance | 9 inbound refs — load-bearing | **CONSOLIDATE** | Right-size **§4.6** ("Community Over Authority") and **§9** ("Community, Governance, and Contribution Model"): remove the multi-maintainer stewardship / revocable-role / decision-"forum" / "no one contributor has full control" framing that dresses a solo study as a standards body. **Preserve** §1–8 and §10–12 (the study's substance) and **all** status/claims wording. Link the real CoC from §9.6. |
+| `CODE_OF_CONDUCT.md` (121 lines) | Contributor Covenant v2.1 | **0 inbound refs (orphan)**; also mis-references another project | **KEEP+EDIT** | The brief keeps a CoC for a professional face. **Fix** the mis-pasted "World Monitor" / `koala73/worldmonitor` references to OMI (pure correctness), and **link** it from README + CONTRIBUTING to remove its orphan status. Not deleted. |
+| `CONTRIBUTING.md` (167 lines) | Contribution workflow | 4 inbound refs — load-bearing | **KEEP+EDIT** | Sound and procedural. Only change: point its "Code of Conduct" section at the actual `CODE_OF_CONDUCT.md`. |
+| `START_HERE.md` (234 lines) | Onboarding / repo map | 6 inbound refs — load-bearing | **KEEP** | Brief-protected (educational identity). Its "community"/tracks framing is normal open-source onboarding aspiration, not standards-body machinery, so it is **kept**. Its broken stage-dir links are **flagged** (§5), consistent with the README. |
+| `SCOPE_V1.md` (161 lines) | Operational v1 scope boundaries | Weak (1 ref) | **KEEP** | Brief-protected; more precise than the charter's scope prose. "When unsure, KEEP." |
+| `LEARNING_ROADMAP.md` (254 lines) | Self-paced learning curriculum | Weak (1 ref) | **KEEP** | Brief leans KEEP — part of the educational identity, not duplicative of the README. |
+
+### 3c. Other meta / docs (non-governance, listed for completeness)
+
+| File / path | Role | Action | Reason |
+|---|---|---|---|
+| `docs/how_omi_is_engineered.md` | Engineering methodology | **KEEP** | Study substance, not governance theater. Carries an SPDX header already. |
+| `docs/08_validation_and_review/templates/**` (6 templates) | L0/L1 PR + review + report templates | **KEEP** | Operational validation artifacts (Stage 8 substance), not consortium theater. |
+| `docs/00…10/**`, `docs/v1/**` | Engineering design-rationale | **KEEP (untouched)** | Hard-protected: this prose *is* the study and feeds later phases. |
+| `meta/` | (empty directory) | **KEEP** | Empty; nothing to do. |
+| `AUDIT_REPO_POSITION.md` | Prior audit working doc (untracked) | **LEAVE UNTRACKED** | Not a requested Phase-0 deliverable; left untracked (neither committed nor deleted). |
+| `PHASE0_DOC_HYGIENE_BRIEF.md` | This phase's briefing (untracked) | **DO NOT COMMIT** | Per the brief, it is a working document, never a repo artifact. |
+
+### 3d. Out of scope — not touched this phase (verbatim hard exclusions)
+
+`design/**` · `design/connector/ddr4_udimm_288_pinmap.csv` ·
+`docs/08_validation_and_review/scripts/**` · `validation/evidence/**`.
+
+---
+
+## 4. What changed (files this PR edits)
+
+| File | Change | One-line description |
+|---|---|---|
+| `PHASE0_CLEANUP_PROPOSAL.md` | added | This decision record (committed artifact). |
+| `README.md` | edited | Renamed `## License` → `## Licensing`, added a license→directory mapping table; added a Code of Conduct link. No status/claims changes. |
+| `CHARTER.md` | edited | Right-sized §4.6 and §9 to a solo-maintained, transparent-but-not-consortium framing; linked the real CoC. Substance (§1–8, §10–12) preserved. |
+| `CODE_OF_CONDUCT.md` | edited | Corrected the mis-pasted "World Monitor" / `koala73/worldmonitor` references to OMI. Content otherwise unchanged (still Contributor Covenant v2.1). |
+| `CONTRIBUTING.md` | edited | Linked the actual `CODE_OF_CONDUCT.md` from its Code of Conduct section. |
+
+**Net file deletions: none.** The right-sizing is achieved by trimming prose inside `CHARTER.md`, not
+by removing files — consistent with the brief's "right-size, do not gut" and "don't over-delete."
+
+---
+
+## 5. Flagged, not fixed (deferred to a later phase)
+
+- **Broken README/START_HERE navigation links** to `docs/05_architecture_decisions/` and
+  `docs/06_block_decomposition/`. These directories do not exist; the real dirs are
+  `docs/05_power_delivery_and_pdn/` and `docs/06_signal_topology_and_routing/`. This is **not** a
+  clean path typo: the README/START_HERE narrative numbers stages as "Stage 5 = Architecture
+  Decisions / Stage 6 = Block Decomposition" (also in the README's *Completed* claims), but the
+  `docs/00…10` tree uses different **topic** names. Repairing the link target alone makes the label
+  incoherent; repairing the label edits the Stage-numbering **status/structure narrative**, which is
+  reserved for the later "make claims honest" phase. Per the brief ("only if cheap and *unambiguous*"
+  + "when unsure, KEEP and flag"), these are left unchanged and flagged here.
+
+- **SPDX headers on Python scripts.** Desirable (the brief recommends it), but every Python file lives
+  under `docs/08_validation_and_review/scripts/**`, a **hard exclusion** this phase. Deferred to the
+  phase that owns those scripts.
+
+- **CC-BY-SA-4.0 vs CC-BY-4.0 for docs.** See Open Question (§6).
+
+---
+
+## 6. Open question (for the reviewer)
+
+> **Recommended:** per-content-type license split —
+> **CERN-OHL-S-2.0** (hardware) / **Apache-2.0** (code) / **CC-BY-SA-4.0** (docs).
+> **Alternative:** consolidate to a single license.
+> Confirm the split, or tell me to unify and I'll amend.
+
+Secondary flag within the split: the docs license is currently **CC-BY-SA-4.0** (ShareAlike /
+copyleft). The brief floated **CC-BY-4.0** (permissive). Kept SA to avoid an unilateral copyleft
+change — say the word to switch.
+
+---
+
+## 7. Verification
+
+- `git status` clean before/after; checkpoint commit (this proposal) precedes any content removal.
+- `main` unchanged; all work on `phase0-doc-hygiene`; no force-push, no history rewrite.
+- Every license file and governance/meta doc has an action + reason in §3.
+- README has a Licensing section mapping license → directory.
+- No out-of-scope artifact touched (`design/**`, the keystone CSV, `docs/08…/scripts/**`,
+  `validation/evidence/**`); design-rationale docs not gutted.
+- No status/claims/maturity wording changed; no rename/rebrand of OMI.
+- Diffs are content-only (no line-ending mass-rewrite).
+- The briefing file and `AUDIT_REPO_POSITION.md` are not committed.
+
+---
+
+## 8. Related docs
+
+- `PHASE0_DOC_HYGIENE_BRIEF.md` — the authoritative Phase 0 spec (working file, untracked).
+- `CHARTER.md`, `README.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` — the edited governance set.
+- `LICENSE`, `LICENSE-docs`, `LICENSE-software` — the three retained licenses.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Before contributing, please read:
 - 📄 **[START_HERE.md](./START_HERE.md)** — onboarding, tracks, and starter tasks
 - 📄 **[CHARTER.md](./CHARTER.md)** — purpose, scope, governance
 - 📄 **[CONTRIBUTING.md](./CONTRIBUTING.md)** — how to participate and what is expected
+- 📄 **[CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)** — the conduct expected of everyone who participates
 
 Good ways to engage:
 

--- a/README.md
+++ b/README.md
@@ -172,16 +172,16 @@ See [CHARTER.md](./CHARTER.md) for the full governance model.
 
 ---
 
-## License
+## Licensing
 
-This project uses a multi-license approach to properly cover all content types:
+This project uses a multi-license approach to properly cover all content types.
+Each license maps to a specific part of the repository:
 
-- **Hardware designs** (schematics, PCB layouts, block decomposition, design artifacts):
-  Licensed under [CERN Open Hardware Licence Version 2 — Strongly Reciprocal (CERN-OHL-S-2.0)](LICENSE)
-- **Documentation** (charter, scope, methodology, learning materials):
-  Licensed under [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](LICENSE-docs)
-- **Software and code** (validation scripts, test tooling, automation):
-  Licensed under [Apache License 2.0](LICENSE-software)
+| Content type | Applies to | License | File |
+|---|---|---|---|
+| Hardware design | `design/**` — schematics, PCB layouts, connector data, design artifacts | CERN Open Hardware Licence v2 — Strongly Reciprocal (CERN-OHL-S-2.0) | [`LICENSE`](LICENSE) |
+| Documentation | `docs/**` and the root prose docs — charter, scope, methodology, learning materials | Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) | [`LICENSE-docs`](LICENSE-docs) |
+| Software / code | Validation scripts, test tooling, automation | Apache License 2.0 | [`LICENSE-software`](LICENSE-software) |
 
 All contributions must comply with these licenses and with the openness and
 redistribution principles defined in [CHARTER.md](CHARTER.md).

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Each license maps to a specific part of the repository:
 |---|---|---|---|
 | Hardware design | `design/**` — schematics, PCB layouts, connector data, design artifacts | CERN Open Hardware Licence v2 — Strongly Reciprocal (CERN-OHL-S-2.0) | [`LICENSE`](LICENSE) |
 | Documentation | `docs/**` and the root prose docs — charter, scope, methodology, learning materials | Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) | [`LICENSE-docs`](LICENSE-docs) |
-| Software / code | Validation scripts, test tooling, automation | Apache License 2.0 | [`LICENSE-software`](LICENSE-software) |
+| Software / code | `docs/08_validation_and_review/scripts/**` — validation scripts, test tooling, automation | Apache License 2.0 | [`LICENSE-software`](LICENSE-software) |
 
 All contributions must comply with these licenses and with the openness and
 redistribution principles defined in [CHARTER.md](CHARTER.md).


### PR DESCRIPTION
## Phase 0 — Documentation & License Hygiene

Right-sizes consortium-grade governance prose and makes the multi-license split explicit, for what is a **single-author DDR4 UDIMM reference-design study**. **No engineering artifacts, no status/claims/maturity wording, and no rename/rebrand were touched** — those belong to later phases. The full decision record is committed in this PR as `PHASE0_CLEANUP_PROPOSAL.md`.

> **Please review on `main` — do not merge yet.** `main` is untouched; history was not rewritten or force-pushed.

### TL;DR
- **Net file deletions: 0.** A read-only inventory disproved the "orphaned / undocumented license" hypothesis: all three license files are **distinct** (MD5-confirmed) and **load-bearing** (each linked from the README), and the split was **already documented** (README + SPDX headers on 7 docs). Per the brief ("right-size, don''t gut"; "never blind-delete a license"; "don''t over-delete"), the right-sizing was achieved by trimming prose **inside** `CHARTER.md`, not by removing files.
- Governance theater trimmed in `CHARTER.md` **§4.6** and **§9** only; the charter''s substance (§1–8, §10–12), scope, and all status/claims wording are untouched.
- Licensing made explicit: README now has a `## Licensing` section mapping **license → directory**.
- **Discovered defect fixed:** the Code of Conduct had been copied from an unrelated project.

### Files changed (5)
| File | Change |
|---|---|
| `PHASE0_CLEANUP_PROPOSAL.md` | **new** — decision record / table. |
| `README.md` | `## License` → `## Licensing` with a license→directory table; added a Code of Conduct link. No status/claims edits. |
| `CHARTER.md` | Right-sized §4.6 + §9 (remove multi-maintainer / decision-"forum" / "community over authority" framing); linked the real CoC. 9-for-9-line in-place reword. |
| `CODE_OF_CONDUCT.md` | Corrected mis-pasted project identity (see below). Still Contributor Covenant v2.1. |
| `CONTRIBUTING.md` | Linked the actual `CODE_OF_CONDUCT.md`. |

### Every "deletion" explained (there are no file deletions — only CHARTER prose was trimmed)
The brief requires an explanation for every deletion. No files were deleted; the only content removed is consortium framing inside `CHARTER.md`:
- **§4.6 "Community Over Authority" → "Decisions Follow Evidence, Not Authority".** Removed "No individual, organization, or sponsor has unilateral control…" and "Authority in OMI is earned through contribution, not position." **Kept** the decision basis (technical merit / evidence / reproducibility). *Why:* the removed lines describe a multi-party power structure that does not exist for a solo study; the engineering principle is preserved.
- **§9 intro + §9.3 "Decision-Making Process".** Removed "Discussions, proposals, and assessments take place in forums linked to project developments" and "No one contributor has full control over the technical direction of the project." **Kept** on-the-record, documented, evidence-based decisions. *Why:* "forums" and a distributed-control body are fictional here; transparency is retained.
- **§9.4 "Maintainers and Stewardship" → "Maintenance".** Removed "Maintainer roles are earned… and can be revoked if responsibilities are left unfulfilled" and the multi-maintainer framing; replaced with "presently maintained by its author… can be shared with sustained contributors as the project grows." **Kept** "stewards of the project''s principles, not gatekeepers." *Why:* there is no maintainer team to earn/revoke roles; this is honest and still leaves the door open.

### Discovered defect: mis-pasted Code of Conduct
`CODE_OF_CONDUCT.md` was a Contributor Covenant copied from a different project:
- pledged to the **"World Monitor community"** (line 7);
- routed incident reports to **`github.com/koala73/worldmonitor/issues`** (line 50).
Both now point to OMI. This is a **correctness fix** (a foreign project''s identity left in OMI''s repo), **not** a rebrand of OMI. The CoC was also orphaned (nothing linked it); it is now linked from README, CONTRIBUTING, and CHARTER §9.6.

### Flagged, not fixed (deferred — see proposal §5)
- **Broken README/START_HERE nav links** to `docs/05_architecture_decisions/` and `docs/06_block_decomposition/` (real dirs: `05_power_delivery_and_pdn`, `06_signal_topology_and_routing`). This is **not** a clean path typo — the link labels carry the "Stage 5 = Architecture Decisions / Stage 6 = Block Decomposition" numbering narrative (also in the README''s status section), so fixing it touches status/structure language reserved for the later "make claims honest" phase. Left unchanged on purpose.
- **SPDX headers on Python scripts** — desirable, but all Python lives under `docs/08_validation_and_review/scripts/**`, a hard exclusion this phase.

### Decision table (condensed — full version in the committed proposal)
| File / path | Role | Referenced? | Action | Reason |
|---|---|---|---|---|
| `LICENSE` | CERN-OHL-S-2.0 (hardware) | README:180 | KEEP | Load-bearing; correct for `design/**`. |
| `LICENSE-docs` | CC-BY-SA-4.0 (docs) | README:182 + 7 SPDX headers | KEEP | Load-bearing; see open question re SA. |
| `LICENSE-software` | Apache-2.0 (code) | README:184 | KEEP | Load-bearing; clean downstream reuse. |
| `README.md` | Front page | entry point | KEEP+EDIT | Licensing table + CoC link. |
| `CHARTER.md` | Charter | 9 refs | CONSOLIDATE | Right-size §4.6/§9. |
| `CODE_OF_CONDUCT.md` | CoC | was orphan | KEEP+EDIT | Fix identity; link it. |
| `CONTRIBUTING.md` | Workflow | 4 refs | KEEP+EDIT | Link CoC. |
| `START_HERE.md` | Onboarding | 6 refs | KEEP | Educational identity; nav links flagged. |
| `SCOPE_V1.md` | v1 scope | weak | KEEP | Operational; "when unsure, keep." |
| `LEARNING_ROADMAP.md` | Curriculum | weak | KEEP | Educational identity. |

### Open question (needs your call)
> **Recommended:** per-content-type license split — **CERN-OHL-S-2.0** (hardware) / **Apache-2.0** (code) / **CC-BY-SA-4.0** (docs).
> **Alternative:** consolidate to a single license.
> Confirm the split, or tell me to unify and I''ll amend.

Secondary flag: the docs license is currently **CC-BY-SA-4.0** (ShareAlike / copyleft); the brief floated **CC-BY-4.0** (permissive). I kept SA to avoid an unilateral copyleft change — say the word to switch.

### Guardrails honored
- `main` unchanged; all work on `phase0-doc-hygiene`; no force-push / history rewrite.
- No out-of-scope artifact touched (`design/**`, the keystone CSV, `docs/08…/scripts/**`, `validation/evidence/**`); design-rationale docs not gutted.
- No status/claims/maturity wording changed; no rename/rebrand of OMI.
- Content-only diffs (no line-ending mass-rewrite); `git fsck` clean.
- The Phase-0 briefing file and the prior audit doc are **not** committed.
