### PR TITLE
Phase 2: 288-pin DDR4 UDIMM edge-connector symbol (generated from CSV)

### DIFF
--- a/build/p2/erc_after.json
+++ b/build/p2/erc_after.json
@@ -1,0 +1,2077 @@
+{
+    "$schema": "https://schemas.kicad.org/erc.v1.json",
+    "coordinate_units": "mm",
+    "date": "2026-06-01T13:55:25+0300",
+    "included_severities": [
+        "error",
+        "warning",
+        "exclusion"
+    ],
+    "kicad_version": "9.0.8",
+    "sheets": [
+        {
+            "path": "/",
+            "uuid_path": "/464309c0-e3ad-4428-a43f-e1cf3b7a7d42",
+            "violations": [
+                {
+                    "description": "Label not connected to anything",
+                    "items": [
+                        {
+                            "description": "Label 'VDDQ'",
+                            "pos": {
+                                "x": 1.6637,
+                                "y": 0.9779
+                            },
+                            "uuid": "2a96067d-6376-4522-a5ee-7f4bf4137123"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "label_dangling"
+                },
+                {
+                    "description": "Label not connected to anything",
+                    "items": [
+                        {
+                            "description": "Label 'VREF'",
+                            "pos": {
+                                "x": 1.6637,
+                                "y": 1.0287
+                            },
+                            "uuid": "16ec7989-7ee3-4d37-ae9a-e6cf697d31a1"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "label_dangling"
+                },
+                {
+                    "description": "Input Power pin not driven by any Output Power pins",
+                    "items": [
+                        {
+                            "description": "Symbol #PWR06 Pin 1 [Power input, Line]",
+                            "pos": {
+                                "x": 1.7145,
+                                "y": 1.0541
+                            },
+                            "uuid": "9e12a576-04ca-4915-9d8b-5319bca49982"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "power_pin_not_driven"
+                },
+                {
+                    "description": "Global label not connected anywhere else in the schematic",
+                    "items": [
+                        {
+                            "description": "Global Label 'VREF'",
+                            "pos": {
+                                "x": 1.778,
+                                "y": 0.127
+                            },
+                            "uuid": "a3658d62-6e5b-52fb-aa3b-d442e140a44e"
+                        }
+                    ],
+                    "severity": "warning",
+                    "type": "global_label_dangling"
+                },
+                {
+                    "description": "Global label not connected anywhere else in the schematic",
+                    "items": [
+                        {
+                            "description": "Global Label 'ALERT_n'",
+                            "pos": {
+                                "x": 1.778,
+                                "y": 1.7018
+                            },
+                            "uuid": "65234f7a-7cbe-599d-ab20-df79cc844670"
+                        }
+                    ],
+                    "severity": "warning",
+                    "type": "global_label_dangling"
+                },
+                {
+                    "description": "Global label not connected anywhere else in the schematic",
+                    "items": [
+                        {
+                            "description": "Global Label 'PARITY'",
+                            "pos": {
+                                "x": 1.778,
+                                "y": 2.0574
+                            },
+                            "uuid": "2f40d281-52ac-5cd7-81da-966a6c5c5028"
+                        }
+                    ],
+                    "severity": "warning",
+                    "type": "global_label_dangling"
+                }
+            ]
+        },
+        {
+            "path": "/address-command-clock/",
+            "uuid_path": "/464309c0-e3ad-4428-a43f-e1cf3b7a7d42/0608c925-7d0a-486c-adfa-f9e150a950d8",
+            "violations": [
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST Pin 40 [Pin_40, Passive, Line]",
+                            "pos": {
+                                "x": 0.3175,
+                                "y": 0.2921
+                            },
+                            "uuid": "ec99780c-b05f-48ce-87d7-40f5f6fca7c0"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST Pin 39 [Pin_39, Passive, Line]",
+                            "pos": {
+                                "x": 0.3429,
+                                "y": 0.2921
+                            },
+                            "uuid": "a43275fd-8438-4615-bab3-49cd2f3c0453"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST Pin 38 [Pin_38, Passive, Line]",
+                            "pos": {
+                                "x": 0.3683,
+                                "y": 0.2921
+                            },
+                            "uuid": "44f1c35e-3db6-4e09-94f3-a1d3d18b418e"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST Pin 37 [Pin_37, Passive, Line]",
+                            "pos": {
+                                "x": 0.3937,
+                                "y": 0.2921
+                            },
+                            "uuid": "6eb1d921-df94-4a9b-8645-c94d1976a4e2"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST Pin 36 [Pin_36, Passive, Line]",
+                            "pos": {
+                                "x": 0.4191,
+                                "y": 0.2921
+                            },
+                            "uuid": "1f63514e-5920-4f93-83d2-3acaa34b72f9"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST Pin 35 [Pin_35, Passive, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 0.2921
+                            },
+                            "uuid": "ab2c88dd-5f32-4f07-83e0-999e687d3fbd"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST Pin 34 [Pin_34, Passive, Line]",
+                            "pos": {
+                                "x": 0.4699,
+                                "y": 0.2921
+                            },
+                            "uuid": "724f180f-8aa1-4949-9c4e-64378a50d251"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST Pin 33 [Pin_33, Passive, Line]",
+                            "pos": {
+                                "x": 0.4953,
+                                "y": 0.2921
+                            },
+                            "uuid": "40875ead-7349-4129-a6ab-708399e802ba"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST Pin 32 [Pin_32, Passive, Line]",
+                            "pos": {
+                                "x": 0.5207,
+                                "y": 0.2921
+                            },
+                            "uuid": "74d52cb4-f65b-4520-913c-9591e1c76527"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST Pin 31 [Pin_31, Passive, Line]",
+                            "pos": {
+                                "x": 0.5461,
+                                "y": 0.2921
+                            },
+                            "uuid": "df4e87e2-b473-4cc4-8c79-07cbc544e16e"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST Pin 30 [Pin_30, Passive, Line]",
+                            "pos": {
+                                "x": 0.5715,
+                                "y": 0.2921
+                            },
+                            "uuid": "2d99fa79-0f48-4743-885d-0c6b728563bc"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input Power pin not driven by any Output Power pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM0 Pin B2 [VDDQ, Power input, Line]",
+                            "pos": {
+                                "x": 0.6223,
+                                "y": 0.5588
+                            },
+                            "uuid": "e004a7e8-f483-4f81-bfca-156a0d28e052"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "power_pin_not_driven"
+                },
+                {
+                    "description": "Input Power pin not driven by any Output Power pins",
+                    "items": [
+                        {
+                            "description": "Symbol #PWR03 Pin 1 [Power input, Line]",
+                            "pos": {
+                                "x": 0.6731,
+                                "y": 0.5588
+                            },
+                            "uuid": "7609cb26-0ddb-447b-b214-73dad484eadb"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "power_pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM0 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 1.143
+                            },
+                            "uuid": "699d6b40-244f-409f-b9ca-63d11e971943"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM0 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 1.143
+                            },
+                            "uuid": "699d6b40-244f-409f-b9ca-63d11e971943"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM0 Pin A3 [TDQS_c, Output, Line]",
+                            "pos": {
+                                "x": 0.8001,
+                                "y": 1.016
+                            },
+                            "uuid": "f63858d9-9539-4a47-ae73-87bf0ecfad8e"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM0 Pin F2 [NC/C2/ODT1, Passive, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 1.2192
+                            },
+                            "uuid": "93a5def1-5f70-44fc-bfdc-f6f7d2697da1"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM0 Pin G8 [NC/C1/~{CS1}, Passive, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 1.27
+                            },
+                            "uuid": "f3eb115d-be3a-4f80-993e-7fd96f17a7ae"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM0 Pin B9 [ZQ, Passive, Line]",
+                            "pos": {
+                                "x": 0.8001,
+                                "y": 1.1176
+                            },
+                            "uuid": "de131f7a-3ac5-4676-ad29-e335f74e959e"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM0 Pin G2 [NC/C0/CKE1, Passive, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 1.3208
+                            },
+                            "uuid": "27c1acbc-1600-4230-ae3c-e83e8d73a8c6"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM0 Pin L9 [~{ALERT}, Open collector, Line]",
+                            "pos": {
+                                "x": 0.8001,
+                                "y": 1.1684
+                            },
+                            "uuid": "74a294e3-8c99-4077-95a0-b9c69db7187c"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input Power pin not driven by any Output Power pins",
+                    "items": [
+                        {
+                            "description": "Symbol #PWR01 Pin 1 [Power input, Line]",
+                            "pos": {
+                                "x": 1.3081,
+                                "y": 0.5588
+                            },
+                            "uuid": "6fcddeff-a6b1-404c-ad09-9144155ec69b"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "power_pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM0 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 1.4478
+                            },
+                            "uuid": "6f82eaef-257d-4e4c-8646-ef8bdf4b47f5"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM0 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 1.4478
+                            },
+                            "uuid": "6f82eaef-257d-4e4c-8646-ef8bdf4b47f5"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM1 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 1.1811,
+                                "y": 1.143
+                            },
+                            "uuid": "b22e637b-7fbd-43c7-b461-2501e5ee0e9e"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM1 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 1.1811,
+                                "y": 1.143
+                            },
+                            "uuid": "b22e637b-7fbd-43c7-b461-2501e5ee0e9e"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM1 Pin F2 [NC/C2/ODT1, Passive, Line]",
+                            "pos": {
+                                "x": 1.1811,
+                                "y": 1.2192
+                            },
+                            "uuid": "8e8e627e-906d-4450-af36-aecf2ba2370c"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM1 Pin G8 [NC/C1/~{CS1}, Passive, Line]",
+                            "pos": {
+                                "x": 1.1811,
+                                "y": 1.27
+                            },
+                            "uuid": "e3954e43-208e-48af-9b84-01eb5075cbf7"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM1 Pin G2 [NC/C0/CKE1, Passive, Line]",
+                            "pos": {
+                                "x": 1.1811,
+                                "y": 1.3208
+                            },
+                            "uuid": "48f7aed5-bc38-4967-8f54-5762e9ea0953"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM1 Pin A3 [TDQS_c, Output, Line]",
+                            "pos": {
+                                "x": 1.5367,
+                                "y": 1.016
+                            },
+                            "uuid": "79ae5450-15ac-4e88-b219-a0b0f5b5fb61"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM1 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 1.1811,
+                                "y": 1.4478
+                            },
+                            "uuid": "e627e74b-0654-45de-b1fa-bca5f0a46671"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM1 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 1.1811,
+                                "y": 1.4478
+                            },
+                            "uuid": "e627e74b-0654-45de-b1fa-bca5f0a46671"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM1 Pin B9 [ZQ, Passive, Line]",
+                            "pos": {
+                                "x": 1.5367,
+                                "y": 1.1176
+                            },
+                            "uuid": "7765cd47-4242-4574-9c60-fc80b85ba7aa"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM1 Pin L9 [~{ALERT}, Open collector, Line]",
+                            "pos": {
+                                "x": 1.5367,
+                                "y": 1.1684
+                            },
+                            "uuid": "2c1b990f-ca65-4f6a-bff7-1ab27a755fd2"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM2 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 1.8923,
+                                "y": 1.143
+                            },
+                            "uuid": "2b64316a-b39b-43d8-bb12-56ed7066ceb3"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM2 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 1.8923,
+                                "y": 1.143
+                            },
+                            "uuid": "2b64316a-b39b-43d8-bb12-56ed7066ceb3"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM2 Pin F2 [NC/C2/ODT1, Passive, Line]",
+                            "pos": {
+                                "x": 1.8923,
+                                "y": 1.2192
+                            },
+                            "uuid": "7e3dd967-9c71-45db-b758-c5f6dad9e98d"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM2 Pin G8 [NC/C1/~{CS1}, Passive, Line]",
+                            "pos": {
+                                "x": 1.8923,
+                                "y": 1.27
+                            },
+                            "uuid": "eb5fcd9e-a0a0-4c0c-a30e-aac444fbd0f9"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM2 Pin G2 [NC/C0/CKE1, Passive, Line]",
+                            "pos": {
+                                "x": 1.8923,
+                                "y": 1.3208
+                            },
+                            "uuid": "b95eb146-be52-4a62-b120-f6081e272691"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM5 Pin A3 [TDQS_c, Output, Line]",
+                            "pos": {
+                                "x": 0.8001,
+                                "y": 2.2098
+                            },
+                            "uuid": "be56e307-f7a1-45e0-a1fd-0cf88780c5b8"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM5 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 2.3368
+                            },
+                            "uuid": "6c227da1-41ee-4c7e-bbfb-85e8d7f99130"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM5 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 2.3368
+                            },
+                            "uuid": "6c227da1-41ee-4c7e-bbfb-85e8d7f99130"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM2 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 1.8923,
+                                "y": 1.4478
+                            },
+                            "uuid": "cfb16353-0356-4bab-8094-fde6bef3a424"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM2 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 1.8923,
+                                "y": 1.4478
+                            },
+                            "uuid": "cfb16353-0356-4bab-8094-fde6bef3a424"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM5 Pin B9 [ZQ, Passive, Line]",
+                            "pos": {
+                                "x": 0.8001,
+                                "y": 2.3114
+                            },
+                            "uuid": "58a23198-61b5-44cd-9238-95c71395d0a5"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM5 Pin F2 [NC/C2/ODT1, Passive, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 2.413
+                            },
+                            "uuid": "8dde2ed8-09c4-4ccb-b207-a898990ae1e4"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM2 Pin A3 [TDQS_c, Output, Line]",
+                            "pos": {
+                                "x": 2.2479,
+                                "y": 1.016
+                            },
+                            "uuid": "c91b3897-9aaa-4fcc-9640-046c6c650f3f"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM5 Pin L9 [~{ALERT}, Open collector, Line]",
+                            "pos": {
+                                "x": 0.8001,
+                                "y": 2.3622
+                            },
+                            "uuid": "07656b85-4c74-4985-a9c7-3e3844e8cca5"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM5 Pin G8 [NC/C1/~{CS1}, Passive, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 2.4638
+                            },
+                            "uuid": "084ce1cd-897e-4d06-b7b4-c23aabd62d74"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM2 Pin B9 [ZQ, Passive, Line]",
+                            "pos": {
+                                "x": 2.2479,
+                                "y": 1.1176
+                            },
+                            "uuid": "7c3ffc68-a9cf-436d-80f2-df48251d713f"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM2 Pin L9 [~{ALERT}, Open collector, Line]",
+                            "pos": {
+                                "x": 2.2479,
+                                "y": 1.1684
+                            },
+                            "uuid": "fcd6a3e2-ab27-41b9-b4b0-b57a444ce576"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM5 Pin G2 [NC/C0/CKE1, Passive, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 2.5146
+                            },
+                            "uuid": "a8294eaa-84f7-4a29-a72b-bc9cf410794e"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM6 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 1.1811,
+                                "y": 2.3368
+                            },
+                            "uuid": "ac147bd7-b963-4538-b813-98d0b42acf9a"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM6 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 1.1811,
+                                "y": 2.3368
+                            },
+                            "uuid": "ac147bd7-b963-4538-b813-98d0b42acf9a"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM5 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 2.6416
+                            },
+                            "uuid": "d2efea68-d737-4911-8d90-7869c364f756"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM5 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 0.4445,
+                                "y": 2.6416
+                            },
+                            "uuid": "d2efea68-d737-4911-8d90-7869c364f756"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM6 Pin F2 [NC/C2/ODT1, Passive, Line]",
+                            "pos": {
+                                "x": 1.1811,
+                                "y": 2.413
+                            },
+                            "uuid": "bf2b8aa8-3f02-49bc-ad31-f81c1e819249"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM6 Pin A3 [TDQS_c, Output, Line]",
+                            "pos": {
+                                "x": 1.5367,
+                                "y": 2.2098
+                            },
+                            "uuid": "eb05f2a8-c889-4c4a-8d4d-66ee959c7de6"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM6 Pin G8 [NC/C1/~{CS1}, Passive, Line]",
+                            "pos": {
+                                "x": 1.1811,
+                                "y": 2.4638
+                            },
+                            "uuid": "db110a13-e3ad-4125-8449-c29ccdadc21a"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM6 Pin B9 [ZQ, Passive, Line]",
+                            "pos": {
+                                "x": 1.5367,
+                                "y": 2.3114
+                            },
+                            "uuid": "a9280856-4c8b-42f8-a27e-790dce17c3a9"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM6 Pin G2 [NC/C0/CKE1, Passive, Line]",
+                            "pos": {
+                                "x": 1.1811,
+                                "y": 2.5146
+                            },
+                            "uuid": "6d87dc24-557d-4aa8-81f5-c98fdc65d17b"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM6 Pin L9 [~{ALERT}, Open collector, Line]",
+                            "pos": {
+                                "x": 1.5367,
+                                "y": 2.3622
+                            },
+                            "uuid": "b4391efd-ba07-4609-b6cd-46f289c9990c"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM3 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 2.5908,
+                                "y": 1.143
+                            },
+                            "uuid": "a2f9741f-0022-4cdd-9391-f0f56218ce37"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM3 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 2.5908,
+                                "y": 1.143
+                            },
+                            "uuid": "a2f9741f-0022-4cdd-9391-f0f56218ce37"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM3 Pin F2 [NC/C2/ODT1, Passive, Line]",
+                            "pos": {
+                                "x": 2.5908,
+                                "y": 1.2192
+                            },
+                            "uuid": "c00647dc-7cab-4d45-8e82-9f87bde9dc2e"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM3 Pin G8 [NC/C1/~{CS1}, Passive, Line]",
+                            "pos": {
+                                "x": 2.5908,
+                                "y": 1.27
+                            },
+                            "uuid": "1c3a73b2-6949-4d12-bfc6-daff831e0a3f"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM6 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 1.1811,
+                                "y": 2.6416
+                            },
+                            "uuid": "f0373fb8-4073-49ee-89cb-8e5c8a41e220"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM6 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 1.1811,
+                                "y": 2.6416
+                            },
+                            "uuid": "f0373fb8-4073-49ee-89cb-8e5c8a41e220"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM3 Pin G2 [NC/C0/CKE1, Passive, Line]",
+                            "pos": {
+                                "x": 2.5908,
+                                "y": 1.3208
+                            },
+                            "uuid": "1e41b328-6d08-4bdf-9cb7-0c79a670ec9d"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM3 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 2.5908,
+                                "y": 1.4478
+                            },
+                            "uuid": "729c859f-f01b-4817-bd05-05ef53e63afe"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM3 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 2.5908,
+                                "y": 1.4478
+                            },
+                            "uuid": "729c859f-f01b-4817-bd05-05ef53e63afe"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM7 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 1.8923,
+                                "y": 2.3495
+                            },
+                            "uuid": "3cc97fde-139a-49c1-b229-2ba24bdbd219"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM7 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 1.8923,
+                                "y": 2.3495
+                            },
+                            "uuid": "3cc97fde-139a-49c1-b229-2ba24bdbd219"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM7 Pin F2 [NC/C2/ODT1, Passive, Line]",
+                            "pos": {
+                                "x": 1.8923,
+                                "y": 2.4257
+                            },
+                            "uuid": "d9e7e723-98c1-4d64-8a59-d4795ddbb44d"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM3 Pin A3 [TDQS_c, Output, Line]",
+                            "pos": {
+                                "x": 2.9464,
+                                "y": 1.016
+                            },
+                            "uuid": "56ab444b-4862-4b14-b108-651559e2392b"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM7 Pin G8 [NC/C1/~{CS1}, Passive, Line]",
+                            "pos": {
+                                "x": 1.8923,
+                                "y": 2.4765
+                            },
+                            "uuid": "9d2cfaf8-c812-43c5-8b38-7ca8bf1925f2"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM3 Pin B9 [ZQ, Passive, Line]",
+                            "pos": {
+                                "x": 2.9464,
+                                "y": 1.1176
+                            },
+                            "uuid": "3789775e-4726-4881-a845-bb6ab0a4282a"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM7 Pin G2 [NC/C0/CKE1, Passive, Line]",
+                            "pos": {
+                                "x": 1.8923,
+                                "y": 2.5273
+                            },
+                            "uuid": "fc59fe12-73ba-4901-b46d-34fa465ec344"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM7 Pin A3 [TDQS_c, Output, Line]",
+                            "pos": {
+                                "x": 2.2479,
+                                "y": 2.2225
+                            },
+                            "uuid": "31a1f583-11f6-4b12-a405-d8818dec3294"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM3 Pin L9 [~{ALERT}, Open collector, Line]",
+                            "pos": {
+                                "x": 2.9464,
+                                "y": 1.1684
+                            },
+                            "uuid": "62777dd5-5b14-4857-82de-eb02ec22f33d"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM7 Pin B9 [ZQ, Passive, Line]",
+                            "pos": {
+                                "x": 2.2479,
+                                "y": 2.3241
+                            },
+                            "uuid": "5c1b8638-d317-4bc2-953f-8c9cd6bef25c"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM7 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 1.8923,
+                                "y": 2.6543
+                            },
+                            "uuid": "c81c7026-137b-48a0-9ca4-235beb6c5f80"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM7 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 1.8923,
+                                "y": 2.6543
+                            },
+                            "uuid": "c81c7026-137b-48a0-9ca4-235beb6c5f80"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM7 Pin L9 [~{ALERT}, Open collector, Line]",
+                            "pos": {
+                                "x": 2.2479,
+                                "y": 2.3749
+                            },
+                            "uuid": "7028db3a-dada-4f66-a864-1fd61f1d1101"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM4 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 3.2893,
+                                "y": 1.1557
+                            },
+                            "uuid": "d3ac4354-1804-42be-8a43-502a872f8ffb"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM4 Pin N3 [PAR, Input, Line]",
+                            "pos": {
+                                "x": 3.2893,
+                                "y": 1.1557
+                            },
+                            "uuid": "d3ac4354-1804-42be-8a43-502a872f8ffb"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM4 Pin F2 [NC/C2/ODT1, Passive, Line]",
+                            "pos": {
+                                "x": 3.2893,
+                                "y": 1.2319
+                            },
+                            "uuid": "6f19ed76-5b5a-4afe-b9fd-3b2222465e8a"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM4 Pin G8 [NC/C1/~{CS1}, Passive, Line]",
+                            "pos": {
+                                "x": 3.2893,
+                                "y": 1.2827
+                            },
+                            "uuid": "fe00cf1f-84da-46d5-8550-e871f7af0636"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM4 Pin G2 [NC/C0/CKE1, Passive, Line]",
+                            "pos": {
+                                "x": 3.2893,
+                                "y": 1.3335
+                            },
+                            "uuid": "7b684da7-8fe7-4c77-8992-7afc56412797"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM4 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 3.2893,
+                                "y": 1.4605
+                            },
+                            "uuid": "7c896cd0-bd7e-4618-bca9-c0060348c024"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input pin not driven by any Output pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM4 Pin G9 [TEN, Input, Line]",
+                            "pos": {
+                                "x": 3.2893,
+                                "y": 1.4605
+                            },
+                            "uuid": "7c896cd0-bd7e-4618-bca9-c0060348c024"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_driven"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM4 Pin A3 [TDQS_c, Output, Line]",
+                            "pos": {
+                                "x": 3.6449,
+                                "y": 1.0287
+                            },
+                            "uuid": "811745f0-7daf-45d2-aeb4-19ce389c8a20"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM4 Pin B9 [ZQ, Passive, Line]",
+                            "pos": {
+                                "x": 3.6449,
+                                "y": 1.1303
+                            },
+                            "uuid": "b42e7ed2-a46c-422d-8ba6-f07289a81c52"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol U_DRAM4 Pin L9 [~{ALERT}, Open collector, Line]",
+                            "pos": {
+                                "x": 3.6449,
+                                "y": 1.1811
+                            },
+                            "uuid": "9de4b743-7355-477e-a11e-fadc3f2db4ea"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                }
+            ]
+        },
+        {
+            "path": "/data-byte-lanes-dqs/",
+            "uuid_path": "/464309c0-e3ad-4428-a43f-e1cf3b7a7d42/a876beee-cefa-449d-aa5c-f6d2865bd67f",
+            "violations": [
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_A Pin 34 [Pin_34, Passive, Line]",
+                            "pos": {
+                                "x": 0.4318,
+                                "y": 1.3843
+                            },
+                            "uuid": "66294ae9-81ff-4c90-9261-17315b356aba"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_A Pin 35 [Pin_35, Passive, Line]",
+                            "pos": {
+                                "x": 0.4318,
+                                "y": 1.4097
+                            },
+                            "uuid": "d128d8a8-0cd5-4f6a-a678-eb184bc8c700"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_A Pin 36 [Pin_36, Passive, Line]",
+                            "pos": {
+                                "x": 0.4318,
+                                "y": 1.4351
+                            },
+                            "uuid": "9b4b8aa3-53ac-4c6a-aeab-c47c971b9226"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_A Pin 37 [Pin_37, Passive, Line]",
+                            "pos": {
+                                "x": 0.4318,
+                                "y": 1.4605
+                            },
+                            "uuid": "4e95ddf2-7d46-4974-afd0-69917f188e22"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_A Pin 38 [Pin_38, Passive, Line]",
+                            "pos": {
+                                "x": 0.4318,
+                                "y": 1.4859
+                            },
+                            "uuid": "3d07da7e-0757-4f96-afe1-9049c6b7cf90"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_A Pin 39 [Pin_39, Passive, Line]",
+                            "pos": {
+                                "x": 0.4318,
+                                "y": 1.5113
+                            },
+                            "uuid": "e140c946-78f7-4555-bb45-052b6591a7c8"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_A Pin 40 [Pin_40, Passive, Line]",
+                            "pos": {
+                                "x": 0.4318,
+                                "y": 1.5367
+                            },
+                            "uuid": "1c35c63b-272c-4b1b-8d94-d749a86457f5"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_B Pin 34 [Pin_34, Passive, Line]",
+                            "pos": {
+                                "x": 1.0922,
+                                "y": 1.3843
+                            },
+                            "uuid": "f16dba6a-f9c3-4f94-8c44-698b8c3c93eb"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_B Pin 35 [Pin_35, Passive, Line]",
+                            "pos": {
+                                "x": 1.0922,
+                                "y": 1.4097
+                            },
+                            "uuid": "5496ec11-521a-434e-820e-5af1e7f8050c"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_B Pin 36 [Pin_36, Passive, Line]",
+                            "pos": {
+                                "x": 1.0922,
+                                "y": 1.4351
+                            },
+                            "uuid": "7c248468-0092-4d44-a3fa-b3f41298fa58"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_B Pin 37 [Pin_37, Passive, Line]",
+                            "pos": {
+                                "x": 1.0922,
+                                "y": 1.4605
+                            },
+                            "uuid": "cabf9708-b14e-4503-aa05-e4df31640194"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_B Pin 38 [Pin_38, Passive, Line]",
+                            "pos": {
+                                "x": 1.0922,
+                                "y": 1.4859
+                            },
+                            "uuid": "f86d591b-794e-4ed7-900e-05e02d25fc7c"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_B Pin 39 [Pin_39, Passive, Line]",
+                            "pos": {
+                                "x": 1.0922,
+                                "y": 1.5113
+                            },
+                            "uuid": "42227275-848b-4acb-9e92-07102f2dc31b"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_B Pin 40 [Pin_40, Passive, Line]",
+                            "pos": {
+                                "x": 1.0922,
+                                "y": 1.5367
+                            },
+                            "uuid": "a9045e00-6daf-487a-a3b6-86e4e90a0569"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 23 [Pin_23, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.1049
+                            },
+                            "uuid": "f7fbcbed-4288-40cb-a2de-5aedd1f0a7e9"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 24 [Pin_24, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.1303
+                            },
+                            "uuid": "6c6d3764-7fb4-4e90-8558-e0afc668a52b"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 25 [Pin_25, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.1557
+                            },
+                            "uuid": "42e6e3bf-d3b8-4b94-85ec-c40d594c796b"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 26 [Pin_26, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.1811
+                            },
+                            "uuid": "a442a40c-d186-48f5-ad5e-f85ac334f052"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 27 [Pin_27, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.2065
+                            },
+                            "uuid": "25267d82-f6c7-4406-80e6-db19740d7ac6"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 28 [Pin_28, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.2319
+                            },
+                            "uuid": "38f75f15-bf77-4069-89bb-257397e296f0"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 29 [Pin_29, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.2573
+                            },
+                            "uuid": "a81e9cc4-4d9f-4529-b04c-df731bf68fd1"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 30 [Pin_30, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.2827
+                            },
+                            "uuid": "724d2fa6-c372-408c-b6d1-d2074a6a2652"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 31 [Pin_31, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.3081
+                            },
+                            "uuid": "f19ab0f6-3a5a-4daa-a9f2-4d6ce6e0283c"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 32 [Pin_32, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.3335
+                            },
+                            "uuid": "fa2228f0-44bc-4145-829f-f86e5d21cf36"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 33 [Pin_33, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.3589
+                            },
+                            "uuid": "b7832b0d-f0b5-4107-8cbc-bc5e45dd3988"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 34 [Pin_34, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.3843
+                            },
+                            "uuid": "1fc21a30-fe69-4193-ad96-0c9a99e8e48f"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 35 [Pin_35, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.4097
+                            },
+                            "uuid": "d862ee92-c17f-4f7d-930f-c31e66095b9e"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 36 [Pin_36, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.4351
+                            },
+                            "uuid": "e8ae06b3-7260-42be-bea0-51b2378c5d6a"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 37 [Pin_37, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.4605
+                            },
+                            "uuid": "d5c86a57-fca2-4d09-9801-2cbf923eb8fe"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 38 [Pin_38, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.4859
+                            },
+                            "uuid": "b10efa9b-9842-42e3-9f50-9b10f3b6871a"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 39 [Pin_39, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.5113
+                            },
+                            "uuid": "772a78f2-cfa0-42ed-84b6-f3571efe8cb0"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_DQ_C Pin 40 [Pin_40, Passive, Line]",
+                            "pos": {
+                                "x": 1.7399,
+                                "y": 1.5367
+                            },
+                            "uuid": "22a9a405-8a2b-4597-a262-bcb98f277d37"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                }
+            ]
+        },
+        {
+            "path": "/spd-and-configuration/",
+            "uuid_path": "/464309c0-e3ad-4428-a43f-e1cf3b7a7d42/32845847-1fe2-4b3a-b24a-3fdd7e5b4214",
+            "violations": [
+                {
+                    "description": "Pin not connected",
+                    "items": [
+                        {
+                            "description": "Symbol J_HOST_SPD Pin 8 [Pin_8, Passive, Line]",
+                            "pos": {
+                                "x": 0.8128,
+                                "y": 1.0922
+                            },
+                            "uuid": "8cb9ab8f-ee16-4ef6-92e2-a0d982891573"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "pin_not_connected"
+                },
+                {
+                    "description": "Input Power pin not driven by any Output Power pins",
+                    "items": [
+                        {
+                            "description": "Symbol U_SPD0 Pin 8 [VCC, Power input, Line]",
+                            "pos": {
+                                "x": 1.6891,
+                                "y": 0.889
+                            },
+                            "uuid": "3df7cbb9-649b-4c3b-827b-5c5fa81898dc"
+                        }
+                    ],
+                    "severity": "error",
+                    "type": "power_pin_not_driven"
+                }
+            ]
+        },
+        {
+            "path": "/udimm-edge-interface/",
+            "uuid_path": "/464309c0-e3ad-4428-a43f-e1cf3b7a7d42/9986c6c0-2ac4-474e-a00a-d8203c8bf46f",
+            "violations": [
+                {
+                    "description": "Local and global labels have same name",
+                    "items": [
+                        {
+                            "description": "Global Label 'VREF'",
+                            "pos": {
+                                "x": 1.778,
+                                "y": 0.127
+                            },
+                            "uuid": "a3658d62-6e5b-52fb-aa3b-d442e140a44e"
+                        },
+                        {
+                            "description": "Label 'VREF'",
+                            "pos": {
+                                "x": 1.6637,
+                                "y": 1.0287
+                            },
+                            "uuid": "16ec7989-7ee3-4d37-ae9a-e6cf697d31a1"
+                        }
+                    ],
+                    "severity": "warning",
+                    "type": "same_local_global_label"
+                }
+            ]
+        }
+    ],
+    "source": "omi_v1_power.kicad_sch"
+}

--- a/build/p2/netlist_after.xml
+++ b/build/p2/netlist_after.xml
@@ -1,0 +1,2568 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<export version="E">
+  <design>
+    <source>C:\Users\senso\OneDrive\Masaüstü\CVWebpage\omi-project\design\power\omi_v1_power\omi_v1_power.kicad_sch</source>
+    <date>2026-06-01T13:55:25+0300</date>
+    <tool>Eeschema 9.0.8</tool>
+    <sheet number="1" name="/" tstamps="/">
+      <title_block>
+        <title>Power &amp; PDN</title>
+        <company>OMI</company>
+        <rev>1.1.0</rev>
+        <date>2026-01-27</date>
+        <source>omi_v1_power.kicad_sch</source>
+        <comment number="1" value="Stage 7.1 — Power Schematic"/>
+        <comment number="2" value="No CA, Data, SPD, or Connector signals allowed"/>
+        <comment number="3" value=""/>
+        <comment number="4" value=""/>
+        <comment number="5" value=""/>
+        <comment number="6" value=""/>
+        <comment number="7" value=""/>
+        <comment number="8" value=""/>
+        <comment number="9" value=""/>
+      </title_block>
+    </sheet>
+    <sheet number="2" name="/address-command-clock/" tstamps="/0608c925-7d0a-486c-adfa-f9e150a950d8/">
+      <title_block>
+        <title>Stage 7.2 - Address / Command / Clock</title>
+        <company>OMI</company>
+        <rev>1.0.0</rev>
+        <date>2026-01-27</date>
+        <source>address-command-clock.kicad_sch</source>
+        <comment number="1" value="Topology: simplified star (schematic); fly-by enforced at layout"/>
+        <comment number="2" value=""/>
+        <comment number="3" value=""/>
+        <comment number="4" value=""/>
+        <comment number="5" value=""/>
+        <comment number="6" value=""/>
+        <comment number="7" value=""/>
+        <comment number="8" value=""/>
+        <comment number="9" value=""/>
+      </title_block>
+    </sheet>
+    <sheet number="3" name="/data-byte-lanes-dqs/" tstamps="/a876beee-cefa-449d-aa5c-f6d2865bd67f/">
+      <title_block>
+        <title/>
+        <company/>
+        <rev/>
+        <date/>
+        <source>data-byte-lanes-dqs.kicad_sch</source>
+        <comment number="1" value=""/>
+        <comment number="2" value=""/>
+        <comment number="3" value=""/>
+        <comment number="4" value=""/>
+        <comment number="5" value=""/>
+        <comment number="6" value=""/>
+        <comment number="7" value=""/>
+        <comment number="8" value=""/>
+        <comment number="9" value=""/>
+      </title_block>
+    </sheet>
+    <sheet number="4" name="/spd-and-configuration/" tstamps="/32845847-1fe2-4b3a-b24a-3fdd7e5b4214/">
+      <title_block>
+        <title>Stage 7.4 — SPD &amp; Configuration</title>
+        <company>OMI</company>
+        <rev/>
+        <date>2026-02-27</date>
+        <source>spd-and-configuration.kicad_sch</source>
+        <comment number="1" value=""/>
+        <comment number="2" value=""/>
+        <comment number="3" value="Assumptions:&#xA;- SMBus pull-ups for SPD_SCL and SPD_SDA are provided by host platform.&#xA;- WP is tied low (writes enabled) for OMI v1 development.&#xA;- SA0/SA1/SA2 are slot/address straps (host-side)."/>
+        <comment number="4" value=""/>
+        <comment number="5" value=""/>
+        <comment number="6" value=""/>
+        <comment number="7" value=""/>
+        <comment number="8" value=""/>
+        <comment number="9" value=""/>
+      </title_block>
+    </sheet>
+    <sheet number="5" name="/udimm-edge-interface/" tstamps="/9986c6c0-2ac4-474e-a00a-d8203c8bf46f/">
+      <title_block>
+        <title/>
+        <company/>
+        <rev/>
+        <date/>
+        <source>udimm-edge-interface.kicad_sch</source>
+        <comment number="1" value=""/>
+        <comment number="2" value=""/>
+        <comment number="3" value=""/>
+        <comment number="4" value=""/>
+        <comment number="5" value=""/>
+        <comment number="6" value=""/>
+        <comment number="7" value=""/>
+        <comment number="8" value=""/>
+        <comment number="9" value=""/>
+      </title_block>
+    </sheet>
+  </design>
+  <components>
+    <comp ref="J_PWR">
+      <value>UDIMM_HOST_POWER</value>
+      <datasheet>~</datasheet>
+      <description>Generic connector, single row, 01x05, script generated (kicad-library-utils/schlib/autogen/connector/)</description>
+      <fields>
+        <field name="Footprint"/>
+        <field name="Datasheet">~</field>
+        <field name="Description">Generic connector, single row, 01x05, script generated (kicad-library-utils/schlib/autogen/connector/)</field>
+      </fields>
+      <libsource lib="Connector_Generic" part="Conn_01x05" description="Generic connector, single row, 01x05, script generated (kicad-library-utils/schlib/autogen/connector/)"/>
+      <property name="Sheetname" value=""/>
+      <property name="Sheetfile" value="omi_v1_power.kicad_sch"/>
+      <property name="ki_keywords" value="connector"/>
+      <property name="ki_fp_filters" value="Connector*:*_1x??_*"/>
+      <sheetpath names="/" tstamps="/"/>
+      <tstamps>bc8fea6b-7341-429b-ac9a-e8ed2cd85230</tstamps>
+    </comp>
+    <comp ref="J_HOST">
+      <value>HOST_CA_CLK (placeholder)</value>
+      <datasheet>~</datasheet>
+      <description>Generic connector, single row, 01x40, script generated (kicad-library-utils/schlib/autogen/connector/)</description>
+      <fields>
+        <field name="Footprint"/>
+        <field name="Datasheet">~</field>
+        <field name="Description">Generic connector, single row, 01x40, script generated (kicad-library-utils/schlib/autogen/connector/)</field>
+      </fields>
+      <libsource lib="Connector_Generic" part="Conn_01x40" description="Generic connector, single row, 01x40, script generated (kicad-library-utils/schlib/autogen/connector/)"/>
+      <property name="Sheetname" value="address-command-clock"/>
+      <property name="Sheetfile" value="address-command-clock.kicad_sch"/>
+      <property name="ki_keywords" value="connector"/>
+      <property name="ki_fp_filters" value="Connector*:*_1x??_*"/>
+      <sheetpath names="/address-command-clock/" tstamps="/0608c925-7d0a-486c-adfa-f9e150a950d8/"/>
+      <tstamps>9130ec8b-c688-434f-b540-3efb2c3ffd98</tstamps>
+    </comp>
+    <comp ref="U_DRAM0">
+      <value>H5AN8G8NAFR-UHC</value>
+      <footprint>Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</footprint>
+      <datasheet>https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</datasheet>
+      <description>8Gb CMOS Double Data Rate IV Synchronous RAM</description>
+      <fields>
+        <field name="Footprint">Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</field>
+        <field name="Datasheet">https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</field>
+        <field name="Description">8Gb CMOS Double Data Rate IV Synchronous RAM</field>
+      </fields>
+      <libsource lib="Memory_RAM" part="H5AN8G8NAFR-UHC" description="8Gb CMOS Double Data Rate IV Synchronous RAM"/>
+      <property name="Sheetname" value="address-command-clock"/>
+      <property name="Sheetfile" value="address-command-clock.kicad_sch"/>
+      <property name="ki_keywords" value="DDR4 DRAM MEMORY"/>
+      <property name="ki_fp_filters" value="FBGA*7.5x11mm*P0.8mm*"/>
+      <sheetpath names="/address-command-clock/" tstamps="/0608c925-7d0a-486c-adfa-f9e150a950d8/"/>
+      <tstamps>c87da998-5365-40b7-9825-ac74fb63029a</tstamps>
+    </comp>
+    <comp ref="U_DRAM1">
+      <value>H5AN8G8NAFR-UHC</value>
+      <footprint>Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</footprint>
+      <datasheet>https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</datasheet>
+      <description>8Gb CMOS Double Data Rate IV Synchronous RAM</description>
+      <fields>
+        <field name="Footprint">Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</field>
+        <field name="Datasheet">https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</field>
+        <field name="Description">8Gb CMOS Double Data Rate IV Synchronous RAM</field>
+      </fields>
+      <libsource lib="Memory_RAM" part="H5AN8G8NAFR-UHC" description="8Gb CMOS Double Data Rate IV Synchronous RAM"/>
+      <property name="Sheetname" value="address-command-clock"/>
+      <property name="Sheetfile" value="address-command-clock.kicad_sch"/>
+      <property name="ki_keywords" value="DDR4 DRAM MEMORY"/>
+      <property name="ki_fp_filters" value="FBGA*7.5x11mm*P0.8mm*"/>
+      <sheetpath names="/address-command-clock/" tstamps="/0608c925-7d0a-486c-adfa-f9e150a950d8/"/>
+      <tstamps>b753772b-97ac-4d86-af3f-17eb106a1347</tstamps>
+    </comp>
+    <comp ref="U_DRAM2">
+      <value>H5AN8G8NAFR-UHC</value>
+      <footprint>Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</footprint>
+      <datasheet>https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</datasheet>
+      <description>8Gb CMOS Double Data Rate IV Synchronous RAM</description>
+      <fields>
+        <field name="Footprint">Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</field>
+        <field name="Datasheet">https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</field>
+        <field name="Description">8Gb CMOS Double Data Rate IV Synchronous RAM</field>
+      </fields>
+      <libsource lib="Memory_RAM" part="H5AN8G8NAFR-UHC" description="8Gb CMOS Double Data Rate IV Synchronous RAM"/>
+      <property name="Sheetname" value="address-command-clock"/>
+      <property name="Sheetfile" value="address-command-clock.kicad_sch"/>
+      <property name="ki_keywords" value="DDR4 DRAM MEMORY"/>
+      <property name="ki_fp_filters" value="FBGA*7.5x11mm*P0.8mm*"/>
+      <sheetpath names="/address-command-clock/" tstamps="/0608c925-7d0a-486c-adfa-f9e150a950d8/"/>
+      <tstamps>54b1968d-8115-4cdf-ab52-8f8d1e1a6d9b</tstamps>
+    </comp>
+    <comp ref="U_DRAM3">
+      <value>H5AN8G8NAFR-UHC</value>
+      <footprint>Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</footprint>
+      <datasheet>https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</datasheet>
+      <description>8Gb CMOS Double Data Rate IV Synchronous RAM</description>
+      <fields>
+        <field name="Footprint">Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</field>
+        <field name="Datasheet">https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</field>
+        <field name="Description">8Gb CMOS Double Data Rate IV Synchronous RAM</field>
+      </fields>
+      <libsource lib="Memory_RAM" part="H5AN8G8NAFR-UHC" description="8Gb CMOS Double Data Rate IV Synchronous RAM"/>
+      <property name="Sheetname" value="address-command-clock"/>
+      <property name="Sheetfile" value="address-command-clock.kicad_sch"/>
+      <property name="ki_keywords" value="DDR4 DRAM MEMORY"/>
+      <property name="ki_fp_filters" value="FBGA*7.5x11mm*P0.8mm*"/>
+      <sheetpath names="/address-command-clock/" tstamps="/0608c925-7d0a-486c-adfa-f9e150a950d8/"/>
+      <tstamps>3adfd6e8-5dda-4dc6-bd4b-eaa59602a5cd</tstamps>
+    </comp>
+    <comp ref="U_DRAM4">
+      <value>H5AN8G8NAFR-UHC</value>
+      <footprint>Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</footprint>
+      <datasheet>https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</datasheet>
+      <description>8Gb CMOS Double Data Rate IV Synchronous RAM</description>
+      <fields>
+        <field name="Footprint">Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</field>
+        <field name="Datasheet">https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</field>
+        <field name="Description">8Gb CMOS Double Data Rate IV Synchronous RAM</field>
+      </fields>
+      <libsource lib="Memory_RAM" part="H5AN8G8NAFR-UHC" description="8Gb CMOS Double Data Rate IV Synchronous RAM"/>
+      <property name="Sheetname" value="address-command-clock"/>
+      <property name="Sheetfile" value="address-command-clock.kicad_sch"/>
+      <property name="ki_keywords" value="DDR4 DRAM MEMORY"/>
+      <property name="ki_fp_filters" value="FBGA*7.5x11mm*P0.8mm*"/>
+      <sheetpath names="/address-command-clock/" tstamps="/0608c925-7d0a-486c-adfa-f9e150a950d8/"/>
+      <tstamps>7c104db6-7a7f-4d63-a545-01c5d261584f</tstamps>
+    </comp>
+    <comp ref="U_DRAM5">
+      <value>H5AN8G8NAFR-UHC</value>
+      <footprint>Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</footprint>
+      <datasheet>https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</datasheet>
+      <description>8Gb CMOS Double Data Rate IV Synchronous RAM</description>
+      <fields>
+        <field name="Footprint">Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</field>
+        <field name="Datasheet">https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</field>
+        <field name="Description">8Gb CMOS Double Data Rate IV Synchronous RAM</field>
+      </fields>
+      <libsource lib="Memory_RAM" part="H5AN8G8NAFR-UHC" description="8Gb CMOS Double Data Rate IV Synchronous RAM"/>
+      <property name="Sheetname" value="address-command-clock"/>
+      <property name="Sheetfile" value="address-command-clock.kicad_sch"/>
+      <property name="ki_keywords" value="DDR4 DRAM MEMORY"/>
+      <property name="ki_fp_filters" value="FBGA*7.5x11mm*P0.8mm*"/>
+      <sheetpath names="/address-command-clock/" tstamps="/0608c925-7d0a-486c-adfa-f9e150a950d8/"/>
+      <tstamps>a340ba36-7ed5-4ae6-8c6f-0b08cb37aaf2</tstamps>
+    </comp>
+    <comp ref="U_DRAM6">
+      <value>H5AN8G8NAFR-UHC</value>
+      <footprint>Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</footprint>
+      <datasheet>https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</datasheet>
+      <description>8Gb CMOS Double Data Rate IV Synchronous RAM</description>
+      <fields>
+        <field name="Footprint">Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</field>
+        <field name="Datasheet">https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</field>
+        <field name="Description">8Gb CMOS Double Data Rate IV Synchronous RAM</field>
+      </fields>
+      <libsource lib="Memory_RAM" part="H5AN8G8NAFR-UHC" description="8Gb CMOS Double Data Rate IV Synchronous RAM"/>
+      <property name="Sheetname" value="address-command-clock"/>
+      <property name="Sheetfile" value="address-command-clock.kicad_sch"/>
+      <property name="ki_keywords" value="DDR4 DRAM MEMORY"/>
+      <property name="ki_fp_filters" value="FBGA*7.5x11mm*P0.8mm*"/>
+      <sheetpath names="/address-command-clock/" tstamps="/0608c925-7d0a-486c-adfa-f9e150a950d8/"/>
+      <tstamps>d5459bee-659f-4d82-8333-c7b3526ed978</tstamps>
+    </comp>
+    <comp ref="U_DRAM7">
+      <value>H5AN8G8NAFR-UHC</value>
+      <footprint>Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</footprint>
+      <datasheet>https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</datasheet>
+      <description>8Gb CMOS Double Data Rate IV Synchronous RAM</description>
+      <fields>
+        <field name="Footprint">Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</field>
+        <field name="Datasheet">https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</field>
+        <field name="Description">8Gb CMOS Double Data Rate IV Synchronous RAM</field>
+      </fields>
+      <libsource lib="Memory_RAM" part="H5AN8G8NAFR-UHC" description="8Gb CMOS Double Data Rate IV Synchronous RAM"/>
+      <property name="Sheetname" value="address-command-clock"/>
+      <property name="Sheetfile" value="address-command-clock.kicad_sch"/>
+      <property name="ki_keywords" value="DDR4 DRAM MEMORY"/>
+      <property name="ki_fp_filters" value="FBGA*7.5x11mm*P0.8mm*"/>
+      <sheetpath names="/address-command-clock/" tstamps="/0608c925-7d0a-486c-adfa-f9e150a950d8/"/>
+      <tstamps>2df63e6b-311b-4b40-905a-4e210e4d8f1a</tstamps>
+    </comp>
+    <comp ref="J_HOST_DQ_A">
+      <value>HOST_DQ_DQS (placeholder)</value>
+      <datasheet>~</datasheet>
+      <description>Generic connector, single row, 01x40, script generated (kicad-library-utils/schlib/autogen/connector/)</description>
+      <fields>
+        <field name="Footprint"/>
+        <field name="Datasheet">~</field>
+        <field name="Description">Generic connector, single row, 01x40, script generated (kicad-library-utils/schlib/autogen/connector/)</field>
+      </fields>
+      <libsource lib="Connector_Generic" part="Conn_01x40" description="Generic connector, single row, 01x40, script generated (kicad-library-utils/schlib/autogen/connector/)"/>
+      <property name="Sheetname" value="data-byte-lanes-dqs"/>
+      <property name="Sheetfile" value="data-byte-lanes-dqs.kicad_sch"/>
+      <property name="ki_keywords" value="connector"/>
+      <property name="ki_fp_filters" value="Connector*:*_1x??_*"/>
+      <sheetpath names="/data-byte-lanes-dqs/" tstamps="/a876beee-cefa-449d-aa5c-f6d2865bd67f/"/>
+      <tstamps>c8b474fe-743d-49e1-b98d-9fb70e005089</tstamps>
+    </comp>
+    <comp ref="J_HOST_DQ_B">
+      <value>HOST_DQ_DQS (placeholder)</value>
+      <datasheet>~</datasheet>
+      <description>Generic connector, single row, 01x40, script generated (kicad-library-utils/schlib/autogen/connector/)</description>
+      <fields>
+        <field name="Footprint"/>
+        <field name="Datasheet">~</field>
+        <field name="Description">Generic connector, single row, 01x40, script generated (kicad-library-utils/schlib/autogen/connector/)</field>
+      </fields>
+      <libsource lib="Connector_Generic" part="Conn_01x40" description="Generic connector, single row, 01x40, script generated (kicad-library-utils/schlib/autogen/connector/)"/>
+      <property name="Sheetname" value="data-byte-lanes-dqs"/>
+      <property name="Sheetfile" value="data-byte-lanes-dqs.kicad_sch"/>
+      <property name="ki_keywords" value="connector"/>
+      <property name="ki_fp_filters" value="Connector*:*_1x??_*"/>
+      <sheetpath names="/data-byte-lanes-dqs/" tstamps="/a876beee-cefa-449d-aa5c-f6d2865bd67f/"/>
+      <tstamps>aaa872eb-8fb6-49aa-a1ff-1486d85e4a6b</tstamps>
+    </comp>
+    <comp ref="J_HOST_DQ_C">
+      <value>HOST_DQ_DQS (placeholder)</value>
+      <datasheet>~</datasheet>
+      <description>Generic connector, single row, 01x40, script generated (kicad-library-utils/schlib/autogen/connector/)</description>
+      <fields>
+        <field name="Footprint"/>
+        <field name="Datasheet">~</field>
+        <field name="Description">Generic connector, single row, 01x40, script generated (kicad-library-utils/schlib/autogen/connector/)</field>
+      </fields>
+      <libsource lib="Connector_Generic" part="Conn_01x40" description="Generic connector, single row, 01x40, script generated (kicad-library-utils/schlib/autogen/connector/)"/>
+      <property name="Sheetname" value="data-byte-lanes-dqs"/>
+      <property name="Sheetfile" value="data-byte-lanes-dqs.kicad_sch"/>
+      <property name="ki_keywords" value="connector"/>
+      <property name="ki_fp_filters" value="Connector*:*_1x??_*"/>
+      <sheetpath names="/data-byte-lanes-dqs/" tstamps="/a876beee-cefa-449d-aa5c-f6d2865bd67f/"/>
+      <tstamps>7ab9b0f4-159b-43de-b266-2ee996cb60b3</tstamps>
+    </comp>
+    <comp ref="J_HOST_SPD">
+      <value>HOST_SMBUS_SPD (placeholder)</value>
+      <datasheet>~</datasheet>
+      <description>Generic connector, single row, 01x08, script generated (kicad-library-utils/schlib/autogen/connector/)</description>
+      <fields>
+        <field name="Footprint"/>
+        <field name="Datasheet">~</field>
+        <field name="Description">Generic connector, single row, 01x08, script generated (kicad-library-utils/schlib/autogen/connector/)</field>
+      </fields>
+      <libsource lib="Connector_Generic" part="Conn_01x08" description="Generic connector, single row, 01x08, script generated (kicad-library-utils/schlib/autogen/connector/)"/>
+      <property name="Sheetname" value="spd-and-configuration"/>
+      <property name="Sheetfile" value="spd-and-configuration.kicad_sch"/>
+      <property name="ki_keywords" value="connector"/>
+      <property name="ki_fp_filters" value="Connector*:*_1x??_*"/>
+      <sheetpath names="/spd-and-configuration/" tstamps="/32845847-1fe2-4b3a-b24a-3fdd7e5b4214/"/>
+      <tstamps>40717e26-6890-4bf9-a9e5-8a084794a2f0</tstamps>
+    </comp>
+    <comp ref="U_SPD0">
+      <value>DDR4_SPD_EEPROM</value>
+      <footprint>Package_DFN_QFN:DFN-8-1EP_3x2mm_P0.5mm_EP1.3x1.5mm</footprint>
+      <datasheet>http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf</datasheet>
+      <description>I2C Serial EEPROM, 1Kb (128x8) with Unique Serial Number, UDFN8</description>
+      <fields>
+        <field name="Footprint">Package_DFN_QFN:DFN-8-1EP_3x2mm_P0.5mm_EP1.3x1.5mm</field>
+        <field name="Datasheet">http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf</field>
+        <field name="Description">I2C Serial EEPROM, 1Kb (128x8) with Unique Serial Number, UDFN8</field>
+      </fields>
+      <libsource lib="Memory_EEPROM" part="AT24CS01-MAHM" description="I2C Serial EEPROM, 1Kb (128x8) with Unique Serial Number, UDFN8"/>
+      <property name="Sheetname" value="spd-and-configuration"/>
+      <property name="Sheetfile" value="spd-and-configuration.kicad_sch"/>
+      <property name="ki_keywords" value="I2C Serial EEPROM Nonvolatile Memory"/>
+      <property name="ki_fp_filters" value="DFN*3x2mm*P0.5mm*"/>
+      <sheetpath names="/spd-and-configuration/" tstamps="/32845847-1fe2-4b3a-b24a-3fdd7e5b4214/"/>
+      <tstamps>669d1028-f1af-40d7-907d-6f4c8b59629b</tstamps>
+    </comp>
+    <comp ref="J1">
+      <value>DDR4_UDIMM_288_Edge</value>
+      <datasheet>~</datasheet>
+      <fields>
+        <field name="Footprint"/>
+        <field name="Datasheet">~</field>
+        <field name="Description"/>
+      </fields>
+      <libsource lib="omi" part="DDR4_UDIMM_288_Edge" description="DDR4 UDIMM 288-pin edge connector; generated from ddr4_udimm_288_pinmap.csv"/>
+      <property name="Sheetname" value="udimm-edge-interface"/>
+      <property name="Sheetfile" value="udimm-edge-interface.kicad_sch"/>
+      <property name="ki_keywords" value="DDR4 UDIMM 288 edge connector DIMM"/>
+      <sheetpath names="/udimm-edge-interface/" tstamps="/9986c6c0-2ac4-474e-a00a-d8203c8bf46f/"/>
+      <tstamps>add96d41-c241-522b-a8f9-fc851009ac2f</tstamps>
+    </comp>
+  </components>
+  <libparts>
+    <libpart lib="Connector_Generic" part="Conn_01x05">
+      <description>Generic connector, single row, 01x05, script generated (kicad-library-utils/schlib/autogen/connector/)</description>
+      <docs>~</docs>
+      <footprints>
+        <fp>Connector*:*_1x??_*</fp>
+      </footprints>
+      <fields>
+        <field name="Reference">J</field>
+        <field name="Value">Conn_01x05</field>
+        <field name="Footprint"/>
+        <field name="Datasheet">~</field>
+        <field name="Description">Generic connector, single row, 01x05, script generated (kicad-library-utils/schlib/autogen/connector/)</field>
+      </fields>
+      <pins>
+        <pin num="1" name="Pin_1" type="passive"/>
+        <pin num="2" name="Pin_2" type="passive"/>
+        <pin num="3" name="Pin_3" type="passive"/>
+        <pin num="4" name="Pin_4" type="passive"/>
+        <pin num="5" name="Pin_5" type="passive"/>
+      </pins>
+    </libpart>
+    <libpart lib="Connector_Generic" part="Conn_01x08">
+      <description>Generic connector, single row, 01x08, script generated (kicad-library-utils/schlib/autogen/connector/)</description>
+      <docs>~</docs>
+      <footprints>
+        <fp>Connector*:*_1x??_*</fp>
+      </footprints>
+      <fields>
+        <field name="Reference">J</field>
+        <field name="Value">Conn_01x08</field>
+        <field name="Footprint"/>
+        <field name="Datasheet">~</field>
+        <field name="Description">Generic connector, single row, 01x08, script generated (kicad-library-utils/schlib/autogen/connector/)</field>
+      </fields>
+      <pins>
+        <pin num="1" name="Pin_1" type="passive"/>
+        <pin num="2" name="Pin_2" type="passive"/>
+        <pin num="3" name="Pin_3" type="passive"/>
+        <pin num="4" name="Pin_4" type="passive"/>
+        <pin num="5" name="Pin_5" type="passive"/>
+        <pin num="6" name="Pin_6" type="passive"/>
+        <pin num="7" name="Pin_7" type="passive"/>
+        <pin num="8" name="Pin_8" type="passive"/>
+      </pins>
+    </libpart>
+    <libpart lib="Connector_Generic" part="Conn_01x40">
+      <description>Generic connector, single row, 01x40, script generated (kicad-library-utils/schlib/autogen/connector/)</description>
+      <docs>~</docs>
+      <footprints>
+        <fp>Connector*:*_1x??_*</fp>
+      </footprints>
+      <fields>
+        <field name="Reference">J</field>
+        <field name="Value">Conn_01x40</field>
+        <field name="Footprint"/>
+        <field name="Datasheet">~</field>
+        <field name="Description">Generic connector, single row, 01x40, script generated (kicad-library-utils/schlib/autogen/connector/)</field>
+      </fields>
+      <pins>
+        <pin num="1" name="Pin_1" type="passive"/>
+        <pin num="2" name="Pin_2" type="passive"/>
+        <pin num="3" name="Pin_3" type="passive"/>
+        <pin num="4" name="Pin_4" type="passive"/>
+        <pin num="5" name="Pin_5" type="passive"/>
+        <pin num="6" name="Pin_6" type="passive"/>
+        <pin num="7" name="Pin_7" type="passive"/>
+        <pin num="8" name="Pin_8" type="passive"/>
+        <pin num="9" name="Pin_9" type="passive"/>
+        <pin num="10" name="Pin_10" type="passive"/>
+        <pin num="11" name="Pin_11" type="passive"/>
+        <pin num="12" name="Pin_12" type="passive"/>
+        <pin num="13" name="Pin_13" type="passive"/>
+        <pin num="14" name="Pin_14" type="passive"/>
+        <pin num="15" name="Pin_15" type="passive"/>
+        <pin num="16" name="Pin_16" type="passive"/>
+        <pin num="17" name="Pin_17" type="passive"/>
+        <pin num="18" name="Pin_18" type="passive"/>
+        <pin num="19" name="Pin_19" type="passive"/>
+        <pin num="20" name="Pin_20" type="passive"/>
+        <pin num="21" name="Pin_21" type="passive"/>
+        <pin num="22" name="Pin_22" type="passive"/>
+        <pin num="23" name="Pin_23" type="passive"/>
+        <pin num="24" name="Pin_24" type="passive"/>
+        <pin num="25" name="Pin_25" type="passive"/>
+        <pin num="26" name="Pin_26" type="passive"/>
+        <pin num="27" name="Pin_27" type="passive"/>
+        <pin num="28" name="Pin_28" type="passive"/>
+        <pin num="29" name="Pin_29" type="passive"/>
+        <pin num="30" name="Pin_30" type="passive"/>
+        <pin num="31" name="Pin_31" type="passive"/>
+        <pin num="32" name="Pin_32" type="passive"/>
+        <pin num="33" name="Pin_33" type="passive"/>
+        <pin num="34" name="Pin_34" type="passive"/>
+        <pin num="35" name="Pin_35" type="passive"/>
+        <pin num="36" name="Pin_36" type="passive"/>
+        <pin num="37" name="Pin_37" type="passive"/>
+        <pin num="38" name="Pin_38" type="passive"/>
+        <pin num="39" name="Pin_39" type="passive"/>
+        <pin num="40" name="Pin_40" type="passive"/>
+      </pins>
+    </libpart>
+    <libpart lib="Memory_EEPROM" part="AT24CS01-MAHM">
+      <description>I2C Serial EEPROM, 1Kb (128x8) with Unique Serial Number, UDFN8</description>
+      <docs>http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf</docs>
+      <footprints>
+        <fp>DFN*3x2mm*P0.5mm*</fp>
+      </footprints>
+      <fields>
+        <field name="Reference">U</field>
+        <field name="Value">AT24CS01-MAHM</field>
+        <field name="Footprint">Package_DFN_QFN:DFN-8-1EP_3x2mm_P0.5mm_EP1.3x1.5mm</field>
+        <field name="Datasheet">http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf</field>
+        <field name="Description">I2C Serial EEPROM, 1Kb (128x8) with Unique Serial Number, UDFN8</field>
+      </fields>
+      <pins>
+        <pin num="1" name="A0" type="input"/>
+        <pin num="2" name="A1" type="input"/>
+        <pin num="3" name="A2" type="input"/>
+        <pin num="4" name="GND" type="power_in"/>
+        <pin num="5" name="SDA" type="bidirectional"/>
+        <pin num="6" name="SCL" type="input"/>
+        <pin num="7" name="WP" type="input"/>
+        <pin num="8" name="VCC" type="power_in"/>
+        <pin num="9" name="GND" type="passive"/>
+      </pins>
+    </libpart>
+    <libpart lib="Memory_RAM" part="H5AN8G8NAFR-UHC">
+      <description>8Gb CMOS Double Data Rate IV Synchronous RAM</description>
+      <docs>https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</docs>
+      <footprints>
+        <fp>FBGA*7.5x11mm*P0.8mm*</fp>
+      </footprints>
+      <fields>
+        <field name="Reference">U</field>
+        <field name="Value">H5AN8G8NAFR-UHC</field>
+        <field name="Footprint">Package_BGA:FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm</field>
+        <field name="Datasheet">https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687</field>
+        <field name="Description">8Gb CMOS Double Data Rate IV Synchronous RAM</field>
+      </fields>
+      <pins>
+        <pin num="A1" name="VDD" type="power_in"/>
+        <pin num="A2" name="VSSQ" type="power_in"/>
+        <pin num="A3" name="TDQS_c" type="output"/>
+        <pin num="A7" name="TDQS_t/~{DM/DBI}" type="bidirectional"/>
+        <pin num="A8" name="VSSQ" type="passive"/>
+        <pin num="A9" name="VSS" type="power_in"/>
+        <pin num="B1" name="VPP" type="power_in"/>
+        <pin num="B2" name="VDDQ" type="power_in"/>
+        <pin num="B3" name="DQS_c" type="bidirectional"/>
+        <pin num="B7" name="DQ1" type="bidirectional"/>
+        <pin num="B8" name="VDDQ" type="passive"/>
+        <pin num="B9" name="ZQ" type="passive"/>
+        <pin num="C1" name="VDDQ" type="passive"/>
+        <pin num="C2" name="DQ0" type="bidirectional"/>
+        <pin num="C3" name="DQS_t" type="bidirectional"/>
+        <pin num="C7" name="VDD" type="passive"/>
+        <pin num="C8" name="VSS" type="passive"/>
+        <pin num="C9" name="VDDQ" type="passive"/>
+        <pin num="D1" name="VSSQ" type="passive"/>
+        <pin num="D2" name="DQ4" type="bidirectional"/>
+        <pin num="D3" name="DQ2" type="bidirectional"/>
+        <pin num="D7" name="DQ3" type="bidirectional"/>
+        <pin num="D8" name="DQ5" type="bidirectional"/>
+        <pin num="D9" name="VSSQ" type="passive"/>
+        <pin num="E1" name="VSS" type="passive"/>
+        <pin num="E2" name="VDDQ" type="passive"/>
+        <pin num="E3" name="DQ6" type="bidirectional"/>
+        <pin num="E7" name="DQ7" type="bidirectional"/>
+        <pin num="E8" name="VDDQ" type="passive"/>
+        <pin num="E9" name="VSS" type="passive"/>
+        <pin num="F1" name="VDD" type="passive"/>
+        <pin num="F2" name="NC/C2/ODT1" type="passive"/>
+        <pin num="F3" name="ODT" type="input"/>
+        <pin num="F7" name="CK_t" type="input"/>
+        <pin num="F8" name="CK_c" type="input"/>
+        <pin num="F9" name="VDD" type="passive"/>
+        <pin num="G1" name="VSS" type="passive"/>
+        <pin num="G2" name="NC/C0/CKE1" type="passive"/>
+        <pin num="G3" name="CKE" type="input"/>
+        <pin num="G7" name="~{CS}" type="input"/>
+        <pin num="G8" name="NC/C1/~{CS1}" type="passive"/>
+        <pin num="G9" name="TEN" type="input"/>
+        <pin num="H1" name="VDD" type="passive"/>
+        <pin num="H2" name="A14/~{WE}" type="input"/>
+        <pin num="H3" name="~{ACT}" type="input"/>
+        <pin num="H7" name="A15/~{CAS}" type="input"/>
+        <pin num="H8" name="A16/~{RAS}" type="input"/>
+        <pin num="H9" name="VSS" type="passive"/>
+        <pin num="J1" name="VREFCA" type="passive"/>
+        <pin num="J2" name="BG0" type="input"/>
+        <pin num="J3" name="A10/AP" type="input"/>
+        <pin num="J7" name="A12/~{BC}" type="input"/>
+        <pin num="J8" name="BG1" type="input"/>
+        <pin num="J9" name="VDD" type="passive"/>
+        <pin num="K1" name="VSS" type="passive"/>
+        <pin num="K2" name="BA0" type="input"/>
+        <pin num="K3" name="A4" type="input"/>
+        <pin num="K7" name="A3" type="input"/>
+        <pin num="K8" name="BA1" type="input"/>
+        <pin num="K9" name="VSS" type="passive"/>
+        <pin num="L1" name="~{RESET}" type="input"/>
+        <pin num="L2" name="A6" type="input"/>
+        <pin num="L3" name="A0" type="input"/>
+        <pin num="L7" name="A1" type="input"/>
+        <pin num="L8" name="A5" type="input"/>
+        <pin num="L9" name="~{ALERT}" type="open_collector"/>
+        <pin num="M1" name="VDD" type="passive"/>
+        <pin num="M2" name="A8" type="input"/>
+        <pin num="M3" name="A2" type="input"/>
+        <pin num="M7" name="A9" type="input"/>
+        <pin num="M8" name="A7" type="input"/>
+        <pin num="M9" name="VPP" type="passive"/>
+        <pin num="N1" name="VSS" type="passive"/>
+        <pin num="N2" name="A11" type="input"/>
+        <pin num="N3" name="PAR" type="input"/>
+        <pin num="N7" name="A17/NC" type="passive"/>
+        <pin num="N8" name="A13" type="input"/>
+        <pin num="N9" name="VDD" type="passive"/>
+      </pins>
+    </libpart>
+    <libpart lib="omi" part="DDR4_UDIMM_288_Edge">
+      <description>DDR4 UDIMM 288-pin edge connector; generated from ddr4_udimm_288_pinmap.csv</description>
+      <docs>~</docs>
+      <fields>
+        <field name="Reference">J</field>
+        <field name="Value">DDR4_UDIMM_288_Edge</field>
+        <field name="Footprint"/>
+        <field name="Datasheet">~</field>
+        <field name="Description">DDR4 UDIMM 288-pin edge connector; generated from ddr4_udimm_288_pinmap.csv</field>
+      </fields>
+      <pins>
+        <pin num="1" name="NC" type="no_connect"/>
+        <pin num="2" name="VSS" type="passive"/>
+        <pin num="3" name="DQ4" type="passive"/>
+        <pin num="4" name="VSS" type="passive"/>
+        <pin num="5" name="DQ0" type="passive"/>
+        <pin num="6" name="VSS" type="passive"/>
+        <pin num="7" name="DM0_n/DBI0_n" type="passive"/>
+        <pin num="8" name="NC" type="no_connect"/>
+        <pin num="9" name="VSS" type="passive"/>
+        <pin num="10" name="DQ6" type="passive"/>
+        <pin num="11" name="VSS" type="passive"/>
+        <pin num="12" name="DQ2" type="passive"/>
+        <pin num="13" name="VSS" type="passive"/>
+        <pin num="14" name="DQ12" type="passive"/>
+        <pin num="15" name="VSS" type="passive"/>
+        <pin num="16" name="DQ8" type="passive"/>
+        <pin num="17" name="VSS" type="passive"/>
+        <pin num="18" name="DM1_n/DBI1_n" type="passive"/>
+        <pin num="19" name="NC" type="no_connect"/>
+        <pin num="20" name="VSS" type="passive"/>
+        <pin num="21" name="DQ14" type="passive"/>
+        <pin num="22" name="VSS" type="passive"/>
+        <pin num="23" name="DQ10" type="passive"/>
+        <pin num="24" name="VSS" type="passive"/>
+        <pin num="25" name="DQ20" type="passive"/>
+        <pin num="26" name="VSS" type="passive"/>
+        <pin num="27" name="DQ16" type="passive"/>
+        <pin num="28" name="VSS" type="passive"/>
+        <pin num="29" name="DM2_n/DBI2_n" type="passive"/>
+        <pin num="30" name="NC" type="no_connect"/>
+        <pin num="31" name="VSS" type="passive"/>
+        <pin num="32" name="DQ22" type="passive"/>
+        <pin num="33" name="VSS" type="passive"/>
+        <pin num="34" name="DQ18" type="passive"/>
+        <pin num="35" name="VSS" type="passive"/>
+        <pin num="36" name="DQ28" type="passive"/>
+        <pin num="37" name="VSS" type="passive"/>
+        <pin num="38" name="DQ24" type="passive"/>
+        <pin num="39" name="VSS" type="passive"/>
+        <pin num="40" name="DM3_n/DBI3_n" type="passive"/>
+        <pin num="41" name="NC" type="no_connect"/>
+        <pin num="42" name="VSS" type="passive"/>
+        <pin num="43" name="DQ30" type="passive"/>
+        <pin num="44" name="VSS" type="passive"/>
+        <pin num="45" name="DQ26" type="passive"/>
+        <pin num="46" name="VSS" type="passive"/>
+        <pin num="47" name="CB4/NC" type="no_connect"/>
+        <pin num="48" name="VSS" type="passive"/>
+        <pin num="49" name="CB0/NC" type="no_connect"/>
+        <pin num="50" name="VSS" type="passive"/>
+        <pin num="51" name="DM8_n/DBI8_n" type="no_connect"/>
+        <pin num="52" name="NC" type="no_connect"/>
+        <pin num="53" name="VSS" type="passive"/>
+        <pin num="54" name="CB6/DBI8_n" type="no_connect"/>
+        <pin num="55" name="VSS" type="passive"/>
+        <pin num="56" name="CB2/NC" type="no_connect"/>
+        <pin num="57" name="VSS" type="passive"/>
+        <pin num="58" name="RESET_n" type="passive"/>
+        <pin num="59" name="VDD" type="passive"/>
+        <pin num="60" name="CKE0" type="passive"/>
+        <pin num="61" name="VDD" type="passive"/>
+        <pin num="62" name="ACT_n" type="passive"/>
+        <pin num="63" name="BG0" type="passive"/>
+        <pin num="64" name="VDD" type="passive"/>
+        <pin num="65" name="A12/BC_n" type="passive"/>
+        <pin num="66" name="A9" type="passive"/>
+        <pin num="67" name="VDD" type="passive"/>
+        <pin num="68" name="A8" type="passive"/>
+        <pin num="69" name="A6" type="passive"/>
+        <pin num="70" name="VDD" type="passive"/>
+        <pin num="71" name="A3" type="passive"/>
+        <pin num="72" name="A1" type="passive"/>
+        <pin num="73" name="VDD" type="passive"/>
+        <pin num="74" name="CK0_t" type="passive"/>
+        <pin num="75" name="CK0_c" type="passive"/>
+        <pin num="76" name="VDD" type="passive"/>
+        <pin num="77" name="VTT" type="passive"/>
+        <pin num="78" name="EVENT_n" type="no_connect"/>
+        <pin num="79" name="A0" type="passive"/>
+        <pin num="80" name="VDD" type="passive"/>
+        <pin num="81" name="BA0" type="passive"/>
+        <pin num="82" name="RAS_n/A16" type="passive"/>
+        <pin num="83" name="VDD" type="passive"/>
+        <pin num="84" name="CS0_n" type="passive"/>
+        <pin num="85" name="VDD" type="passive"/>
+        <pin num="86" name="CAS_n/A15" type="passive"/>
+        <pin num="87" name="ODT0" type="passive"/>
+        <pin num="88" name="VDD" type="passive"/>
+        <pin num="89" name="CS1_n" type="no_connect"/>
+        <pin num="90" name="VDD" type="passive"/>
+        <pin num="91" name="ODT1" type="no_connect"/>
+        <pin num="92" name="VDD" type="passive"/>
+        <pin num="93" name="NC" type="no_connect"/>
+        <pin num="94" name="VSS" type="passive"/>
+        <pin num="95" name="DQ36" type="passive"/>
+        <pin num="96" name="VSS" type="passive"/>
+        <pin num="97" name="DQ32" type="passive"/>
+        <pin num="98" name="VSS" type="passive"/>
+        <pin num="99" name="DM4_n/DBI4_n" type="passive"/>
+        <pin num="100" name="NC" type="no_connect"/>
+        <pin num="101" name="VSS" type="passive"/>
+        <pin num="102" name="DQ38" type="passive"/>
+        <pin num="103" name="VSS" type="passive"/>
+        <pin num="104" name="DQ34" type="passive"/>
+        <pin num="105" name="VSS" type="passive"/>
+        <pin num="106" name="DQ44" type="passive"/>
+        <pin num="107" name="VSS" type="passive"/>
+        <pin num="108" name="DQ40" type="passive"/>
+        <pin num="109" name="VSS" type="passive"/>
+        <pin num="110" name="DM5_n/DBI5_n" type="passive"/>
+        <pin num="111" name="NC" type="no_connect"/>
+        <pin num="112" name="VSS" type="passive"/>
+        <pin num="113" name="DQ46" type="passive"/>
+        <pin num="114" name="VSS" type="passive"/>
+        <pin num="115" name="DQ42" type="passive"/>
+        <pin num="116" name="VSS" type="passive"/>
+        <pin num="117" name="DQ52" type="passive"/>
+        <pin num="118" name="VSS" type="passive"/>
+        <pin num="119" name="DQ48" type="passive"/>
+        <pin num="120" name="VSS" type="passive"/>
+        <pin num="121" name="DM6_n/DBI6_n" type="passive"/>
+        <pin num="122" name="NC" type="no_connect"/>
+        <pin num="123" name="VSS" type="passive"/>
+        <pin num="124" name="DQ54" type="passive"/>
+        <pin num="125" name="VSS" type="passive"/>
+        <pin num="126" name="DQ50" type="passive"/>
+        <pin num="127" name="VSS" type="passive"/>
+        <pin num="128" name="DQ60" type="passive"/>
+        <pin num="129" name="VSS" type="passive"/>
+        <pin num="130" name="DQ56" type="passive"/>
+        <pin num="131" name="VSS" type="passive"/>
+        <pin num="132" name="DM7_n/DBI7_n" type="passive"/>
+        <pin num="133" name="NC" type="no_connect"/>
+        <pin num="134" name="VSS" type="passive"/>
+        <pin num="135" name="DQ62" type="passive"/>
+        <pin num="136" name="VSS" type="passive"/>
+        <pin num="137" name="DQ58" type="passive"/>
+        <pin num="138" name="VSS" type="passive"/>
+        <pin num="139" name="SA0" type="passive"/>
+        <pin num="140" name="SA1" type="passive"/>
+        <pin num="141" name="SCL" type="passive"/>
+        <pin num="142" name="VPP" type="passive"/>
+        <pin num="143" name="VPP" type="passive"/>
+        <pin num="144" name="NC" type="no_connect"/>
+        <pin num="145" name="NC" type="no_connect"/>
+        <pin num="146" name="VREFCA" type="passive"/>
+        <pin num="147" name="VSS" type="passive"/>
+        <pin num="148" name="DQ5" type="passive"/>
+        <pin num="149" name="VSS" type="passive"/>
+        <pin num="150" name="DQ1" type="passive"/>
+        <pin num="151" name="VSS" type="passive"/>
+        <pin num="152" name="DQS0_c" type="passive"/>
+        <pin num="153" name="DQS0_t" type="passive"/>
+        <pin num="154" name="VSS" type="passive"/>
+        <pin num="155" name="DQ7" type="passive"/>
+        <pin num="156" name="VSS" type="passive"/>
+        <pin num="157" name="DQ3" type="passive"/>
+        <pin num="158" name="VSS" type="passive"/>
+        <pin num="159" name="DQ13" type="passive"/>
+        <pin num="160" name="VSS" type="passive"/>
+        <pin num="161" name="DQ9" type="passive"/>
+        <pin num="162" name="VSS" type="passive"/>
+        <pin num="163" name="DQS1_c" type="passive"/>
+        <pin num="164" name="DQS1_t" type="passive"/>
+        <pin num="165" name="VSS" type="passive"/>
+        <pin num="166" name="DQ15" type="passive"/>
+        <pin num="167" name="VSS" type="passive"/>
+        <pin num="168" name="DQ11" type="passive"/>
+        <pin num="169" name="VSS" type="passive"/>
+        <pin num="170" name="DQ21" type="passive"/>
+        <pin num="171" name="VSS" type="passive"/>
+        <pin num="172" name="DQ17" type="passive"/>
+        <pin num="173" name="VSS" type="passive"/>
+        <pin num="174" name="DQS2_c" type="passive"/>
+        <pin num="175" name="DQS2_t" type="passive"/>
+        <pin num="176" name="VSS" type="passive"/>
+        <pin num="177" name="DQ23" type="passive"/>
+        <pin num="178" name="VSS" type="passive"/>
+        <pin num="179" name="DQ19" type="passive"/>
+        <pin num="180" name="VSS" type="passive"/>
+        <pin num="181" name="DQ29" type="passive"/>
+        <pin num="182" name="VSS" type="passive"/>
+        <pin num="183" name="DQ25" type="passive"/>
+        <pin num="184" name="VSS" type="passive"/>
+        <pin num="185" name="DQS3_c" type="passive"/>
+        <pin num="186" name="DQS3_t" type="passive"/>
+        <pin num="187" name="VSS" type="passive"/>
+        <pin num="188" name="DQ31" type="passive"/>
+        <pin num="189" name="VSS" type="passive"/>
+        <pin num="190" name="DQ27" type="passive"/>
+        <pin num="191" name="VSS" type="passive"/>
+        <pin num="192" name="CB5/NC" type="no_connect"/>
+        <pin num="193" name="VSS" type="passive"/>
+        <pin num="194" name="CB1/NC" type="no_connect"/>
+        <pin num="195" name="VSS" type="passive"/>
+        <pin num="196" name="DQS8_c" type="no_connect"/>
+        <pin num="197" name="DQS8_t" type="no_connect"/>
+        <pin num="198" name="VSS" type="passive"/>
+        <pin num="199" name="CB7/NC" type="no_connect"/>
+        <pin num="200" name="VSS" type="passive"/>
+        <pin num="201" name="CB3/NC" type="no_connect"/>
+        <pin num="202" name="VSS" type="passive"/>
+        <pin num="203" name="CKE1" type="no_connect"/>
+        <pin num="204" name="VDD" type="passive"/>
+        <pin num="205" name="NC" type="no_connect"/>
+        <pin num="206" name="VDD" type="passive"/>
+        <pin num="207" name="BG1" type="passive"/>
+        <pin num="208" name="ALERT_n" type="passive"/>
+        <pin num="209" name="VDD" type="passive"/>
+        <pin num="210" name="A11" type="passive"/>
+        <pin num="211" name="A7" type="passive"/>
+        <pin num="212" name="VDD" type="passive"/>
+        <pin num="213" name="A5" type="passive"/>
+        <pin num="214" name="A4" type="passive"/>
+        <pin num="215" name="VDD" type="passive"/>
+        <pin num="216" name="A2" type="passive"/>
+        <pin num="217" name="VDD" type="passive"/>
+        <pin num="218" name="CK1_t" type="no_connect"/>
+        <pin num="219" name="CK1_c" type="no_connect"/>
+        <pin num="220" name="VDD" type="passive"/>
+        <pin num="221" name="VTT" type="passive"/>
+        <pin num="222" name="PARITY" type="passive"/>
+        <pin num="223" name="VDD" type="passive"/>
+        <pin num="224" name="BA1" type="passive"/>
+        <pin num="225" name="A10/AP" type="passive"/>
+        <pin num="226" name="VDD" type="passive"/>
+        <pin num="227" name="NC" type="no_connect"/>
+        <pin num="228" name="WE_n/A14" type="passive"/>
+        <pin num="229" name="VDD" type="passive"/>
+        <pin num="230" name="NC" type="no_connect"/>
+        <pin num="231" name="VDD" type="passive"/>
+        <pin num="232" name="A13" type="passive"/>
+        <pin num="233" name="VDD" type="passive"/>
+        <pin num="234" name="NC" type="no_connect"/>
+        <pin num="235" name="NC" type="no_connect"/>
+        <pin num="236" name="VDD" type="passive"/>
+        <pin num="237" name="NC" type="no_connect"/>
+        <pin num="238" name="SA2" type="passive"/>
+        <pin num="239" name="VDD" type="passive"/>
+        <pin num="240" name="DQ37" type="passive"/>
+        <pin num="241" name="VSS" type="passive"/>
+        <pin num="242" name="DQ33" type="passive"/>
+        <pin num="243" name="VSS" type="passive"/>
+        <pin num="244" name="DQS4_c" type="passive"/>
+        <pin num="245" name="DQS4_t" type="passive"/>
+        <pin num="246" name="VSS" type="passive"/>
+        <pin num="247" name="DQ39" type="passive"/>
+        <pin num="248" name="VSS" type="passive"/>
+        <pin num="249" name="DQ35" type="passive"/>
+        <pin num="250" name="VSS" type="passive"/>
+        <pin num="251" name="DQ45" type="passive"/>
+        <pin num="252" name="VSS" type="passive"/>
+        <pin num="253" name="DQ41" type="passive"/>
+        <pin num="254" name="VSS" type="passive"/>
+        <pin num="255" name="DQS5_c" type="passive"/>
+        <pin num="256" name="DQS5_t" type="passive"/>
+        <pin num="257" name="VSS" type="passive"/>
+        <pin num="258" name="DQ47" type="passive"/>
+        <pin num="259" name="VSS" type="passive"/>
+        <pin num="260" name="DQ43" type="passive"/>
+        <pin num="261" name="VSS" type="passive"/>
+        <pin num="262" name="DQ53" type="passive"/>
+        <pin num="263" name="VSS" type="passive"/>
+        <pin num="264" name="DQ49" type="passive"/>
+        <pin num="265" name="VSS" type="passive"/>
+        <pin num="266" name="DQS6_c" type="passive"/>
+        <pin num="267" name="DQS6_t" type="passive"/>
+        <pin num="268" name="VSS" type="passive"/>
+        <pin num="269" name="DQ55" type="passive"/>
+        <pin num="270" name="VSS" type="passive"/>
+        <pin num="271" name="DQ51" type="passive"/>
+        <pin num="272" name="VSS" type="passive"/>
+        <pin num="273" name="DQ61" type="passive"/>
+        <pin num="274" name="VSS" type="passive"/>
+        <pin num="275" name="DQ57" type="passive"/>
+        <pin num="276" name="VSS" type="passive"/>
+        <pin num="277" name="DQS7_c" type="passive"/>
+        <pin num="278" name="DQS7_t" type="passive"/>
+        <pin num="279" name="VSS" type="passive"/>
+        <pin num="280" name="DQ63" type="passive"/>
+        <pin num="281" name="VSS" type="passive"/>
+        <pin num="282" name="DQ59" type="passive"/>
+        <pin num="283" name="VSS" type="passive"/>
+        <pin num="284" name="VDDSPD" type="passive"/>
+        <pin num="285" name="SDA" type="passive"/>
+        <pin num="286" name="VPP" type="passive"/>
+        <pin num="287" name="VPP" type="passive"/>
+        <pin num="288" name="VPP" type="passive"/>
+      </pins>
+    </libpart>
+  </libparts>
+  <libraries>
+    <library logical="Connector_Generic">
+      <uri>C:\Users\senso\AppData\Local\Programs\KiCad\9.0\share\kicad\symbols\/Connector_Generic.kicad_sym</uri>
+    </library>
+    <library logical="Memory_EEPROM">
+      <uri>C:\Users\senso\AppData\Local\Programs\KiCad\9.0\share\kicad\symbols\/Memory_EEPROM.kicad_sym</uri>
+    </library>
+    <library logical="Memory_RAM">
+      <uri>C:\Users\senso\AppData\Local\Programs\KiCad\9.0\share\kicad\symbols\/Memory_RAM.kicad_sym</uri>
+    </library>
+    <library logical="omi">
+      <uri>C:\Users\senso\OneDrive\Masaüstü\CVWebpage\omi-project\design\power\omi_v1_power/omi.kicad_sym</uri>
+    </library>
+  </libraries>
+  <nets>
+    <net code="1" name="/VDDQ" class="Default">
+      <node ref="J_PWR" pin="2" pinfunction="Pin_2" pintype="passive"/>
+    </net>
+    <net code="2" name="/VREF" class="Default">
+      <node ref="J_PWR" pin="4" pinfunction="Pin_4" pintype="passive"/>
+    </net>
+    <net code="3" name="/address-command-clock/VDDQ" class="Default">
+      <node ref="U_DRAM0" pin="B2" pinfunction="VDDQ" pintype="power_in"/>
+      <node ref="U_DRAM0" pin="B8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM0" pin="C1" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM0" pin="C9" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM0" pin="E2" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM0" pin="E8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM1" pin="B2" pinfunction="VDDQ" pintype="power_in"/>
+      <node ref="U_DRAM1" pin="B8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM1" pin="C1" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM1" pin="C9" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM1" pin="E2" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM1" pin="E8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM2" pin="B2" pinfunction="VDDQ" pintype="power_in"/>
+      <node ref="U_DRAM2" pin="B8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM2" pin="C1" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM2" pin="C9" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM2" pin="E2" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM2" pin="E8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM3" pin="B2" pinfunction="VDDQ" pintype="power_in"/>
+      <node ref="U_DRAM3" pin="B8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM3" pin="C1" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM3" pin="C9" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM3" pin="E2" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM3" pin="E8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM4" pin="B2" pinfunction="VDDQ" pintype="power_in"/>
+      <node ref="U_DRAM4" pin="B8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM4" pin="C1" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM4" pin="C9" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM4" pin="E2" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM4" pin="E8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM5" pin="B2" pinfunction="VDDQ" pintype="power_in"/>
+      <node ref="U_DRAM5" pin="B8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM5" pin="C1" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM5" pin="C9" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM5" pin="E2" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM5" pin="E8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM6" pin="B2" pinfunction="VDDQ" pintype="power_in"/>
+      <node ref="U_DRAM6" pin="B8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM6" pin="C1" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM6" pin="C9" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM6" pin="E2" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM6" pin="E8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM7" pin="B2" pinfunction="VDDQ" pintype="power_in"/>
+      <node ref="U_DRAM7" pin="B8" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM7" pin="C1" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM7" pin="C9" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM7" pin="E2" pinfunction="VDDQ" pintype="passive"/>
+      <node ref="U_DRAM7" pin="E8" pinfunction="VDDQ" pintype="passive"/>
+    </net>
+    <net code="4" name="/address-command-clock/VREF" class="Default">
+      <node ref="U_DRAM0" pin="J1" pinfunction="VREFCA" pintype="passive"/>
+      <node ref="U_DRAM1" pin="J1" pinfunction="VREFCA" pintype="passive"/>
+      <node ref="U_DRAM2" pin="J1" pinfunction="VREFCA" pintype="passive"/>
+      <node ref="U_DRAM3" pin="J1" pinfunction="VREFCA" pintype="passive"/>
+      <node ref="U_DRAM4" pin="J1" pinfunction="VREFCA" pintype="passive"/>
+      <node ref="U_DRAM5" pin="J1" pinfunction="VREFCA" pintype="passive"/>
+      <node ref="U_DRAM6" pin="J1" pinfunction="VREFCA" pintype="passive"/>
+      <node ref="U_DRAM7" pin="J1" pinfunction="VREFCA" pintype="passive"/>
+    </net>
+    <net code="5" name="A0" class="Default">
+      <node ref="J1" pin="79" pinfunction="A0" pintype="passive"/>
+      <node ref="J_HOST" pin="12" pinfunction="Pin_12" pintype="passive"/>
+      <node ref="U_DRAM0" pin="L3" pinfunction="A0" pintype="input"/>
+      <node ref="U_DRAM1" pin="L3" pinfunction="A0" pintype="input"/>
+      <node ref="U_DRAM2" pin="L3" pinfunction="A0" pintype="input"/>
+      <node ref="U_DRAM3" pin="L3" pinfunction="A0" pintype="input"/>
+      <node ref="U_DRAM4" pin="L3" pinfunction="A0" pintype="input"/>
+      <node ref="U_DRAM5" pin="L3" pinfunction="A0" pintype="input"/>
+      <node ref="U_DRAM6" pin="L3" pinfunction="A0" pintype="input"/>
+      <node ref="U_DRAM7" pin="L3" pinfunction="A0" pintype="input"/>
+    </net>
+    <net code="6" name="A1" class="Default">
+      <node ref="J1" pin="72" pinfunction="A1" pintype="passive"/>
+      <node ref="J_HOST" pin="13" pinfunction="Pin_13" pintype="passive"/>
+      <node ref="U_DRAM0" pin="L7" pinfunction="A1" pintype="input"/>
+      <node ref="U_DRAM1" pin="L7" pinfunction="A1" pintype="input"/>
+      <node ref="U_DRAM2" pin="L7" pinfunction="A1" pintype="input"/>
+      <node ref="U_DRAM3" pin="L7" pinfunction="A1" pintype="input"/>
+      <node ref="U_DRAM4" pin="L7" pinfunction="A1" pintype="input"/>
+      <node ref="U_DRAM5" pin="L7" pinfunction="A1" pintype="input"/>
+      <node ref="U_DRAM6" pin="L7" pinfunction="A1" pintype="input"/>
+      <node ref="U_DRAM7" pin="L7" pinfunction="A1" pintype="input"/>
+    </net>
+    <net code="7" name="A2" class="Default">
+      <node ref="J1" pin="216" pinfunction="A2" pintype="passive"/>
+      <node ref="J_HOST" pin="14" pinfunction="Pin_14" pintype="passive"/>
+      <node ref="U_DRAM0" pin="M3" pinfunction="A2" pintype="input"/>
+      <node ref="U_DRAM1" pin="M3" pinfunction="A2" pintype="input"/>
+      <node ref="U_DRAM2" pin="M3" pinfunction="A2" pintype="input"/>
+      <node ref="U_DRAM3" pin="M3" pinfunction="A2" pintype="input"/>
+      <node ref="U_DRAM4" pin="M3" pinfunction="A2" pintype="input"/>
+      <node ref="U_DRAM5" pin="M3" pinfunction="A2" pintype="input"/>
+      <node ref="U_DRAM6" pin="M3" pinfunction="A2" pintype="input"/>
+      <node ref="U_DRAM7" pin="M3" pinfunction="A2" pintype="input"/>
+    </net>
+    <net code="8" name="A3" class="Default">
+      <node ref="J1" pin="71" pinfunction="A3" pintype="passive"/>
+      <node ref="J_HOST" pin="15" pinfunction="Pin_15" pintype="passive"/>
+      <node ref="U_DRAM0" pin="K7" pinfunction="A3" pintype="input"/>
+      <node ref="U_DRAM1" pin="K7" pinfunction="A3" pintype="input"/>
+      <node ref="U_DRAM2" pin="K7" pinfunction="A3" pintype="input"/>
+      <node ref="U_DRAM3" pin="K7" pinfunction="A3" pintype="input"/>
+      <node ref="U_DRAM4" pin="K7" pinfunction="A3" pintype="input"/>
+      <node ref="U_DRAM5" pin="K7" pinfunction="A3" pintype="input"/>
+      <node ref="U_DRAM6" pin="K7" pinfunction="A3" pintype="input"/>
+      <node ref="U_DRAM7" pin="K7" pinfunction="A3" pintype="input"/>
+    </net>
+    <net code="9" name="A4" class="Default">
+      <node ref="J1" pin="214" pinfunction="A4" pintype="passive"/>
+      <node ref="J_HOST" pin="16" pinfunction="Pin_16" pintype="passive"/>
+      <node ref="U_DRAM0" pin="K3" pinfunction="A4" pintype="input"/>
+      <node ref="U_DRAM1" pin="K3" pinfunction="A4" pintype="input"/>
+      <node ref="U_DRAM2" pin="K3" pinfunction="A4" pintype="input"/>
+      <node ref="U_DRAM3" pin="K3" pinfunction="A4" pintype="input"/>
+      <node ref="U_DRAM4" pin="K3" pinfunction="A4" pintype="input"/>
+      <node ref="U_DRAM5" pin="K3" pinfunction="A4" pintype="input"/>
+      <node ref="U_DRAM6" pin="K3" pinfunction="A4" pintype="input"/>
+      <node ref="U_DRAM7" pin="K3" pinfunction="A4" pintype="input"/>
+    </net>
+    <net code="10" name="A5" class="Default">
+      <node ref="J1" pin="213" pinfunction="A5" pintype="passive"/>
+      <node ref="J_HOST" pin="17" pinfunction="Pin_17" pintype="passive"/>
+      <node ref="U_DRAM0" pin="L8" pinfunction="A5" pintype="input"/>
+      <node ref="U_DRAM1" pin="L8" pinfunction="A5" pintype="input"/>
+      <node ref="U_DRAM2" pin="L8" pinfunction="A5" pintype="input"/>
+      <node ref="U_DRAM3" pin="L8" pinfunction="A5" pintype="input"/>
+      <node ref="U_DRAM4" pin="L8" pinfunction="A5" pintype="input"/>
+      <node ref="U_DRAM5" pin="L8" pinfunction="A5" pintype="input"/>
+      <node ref="U_DRAM6" pin="L8" pinfunction="A5" pintype="input"/>
+      <node ref="U_DRAM7" pin="L8" pinfunction="A5" pintype="input"/>
+    </net>
+    <net code="11" name="A6" class="Default">
+      <node ref="J1" pin="69" pinfunction="A6" pintype="passive"/>
+      <node ref="J_HOST" pin="18" pinfunction="Pin_18" pintype="passive"/>
+      <node ref="U_DRAM0" pin="L2" pinfunction="A6" pintype="input"/>
+      <node ref="U_DRAM1" pin="L2" pinfunction="A6" pintype="input"/>
+      <node ref="U_DRAM2" pin="L2" pinfunction="A6" pintype="input"/>
+      <node ref="U_DRAM3" pin="L2" pinfunction="A6" pintype="input"/>
+      <node ref="U_DRAM4" pin="L2" pinfunction="A6" pintype="input"/>
+      <node ref="U_DRAM5" pin="L2" pinfunction="A6" pintype="input"/>
+      <node ref="U_DRAM6" pin="L2" pinfunction="A6" pintype="input"/>
+      <node ref="U_DRAM7" pin="L2" pinfunction="A6" pintype="input"/>
+    </net>
+    <net code="12" name="A7" class="Default">
+      <node ref="J1" pin="211" pinfunction="A7" pintype="passive"/>
+      <node ref="J_HOST" pin="19" pinfunction="Pin_19" pintype="passive"/>
+      <node ref="U_DRAM0" pin="M8" pinfunction="A7" pintype="input"/>
+      <node ref="U_DRAM1" pin="M8" pinfunction="A7" pintype="input"/>
+      <node ref="U_DRAM2" pin="M8" pinfunction="A7" pintype="input"/>
+      <node ref="U_DRAM3" pin="M8" pinfunction="A7" pintype="input"/>
+      <node ref="U_DRAM4" pin="M8" pinfunction="A7" pintype="input"/>
+      <node ref="U_DRAM5" pin="M8" pinfunction="A7" pintype="input"/>
+      <node ref="U_DRAM6" pin="M8" pinfunction="A7" pintype="input"/>
+      <node ref="U_DRAM7" pin="M8" pinfunction="A7" pintype="input"/>
+    </net>
+    <net code="13" name="A8" class="Default">
+      <node ref="J1" pin="68" pinfunction="A8" pintype="passive"/>
+      <node ref="J_HOST" pin="20" pinfunction="Pin_20" pintype="passive"/>
+      <node ref="U_DRAM0" pin="M2" pinfunction="A8" pintype="input"/>
+      <node ref="U_DRAM1" pin="M2" pinfunction="A8" pintype="input"/>
+      <node ref="U_DRAM2" pin="M2" pinfunction="A8" pintype="input"/>
+      <node ref="U_DRAM3" pin="M2" pinfunction="A8" pintype="input"/>
+      <node ref="U_DRAM4" pin="M2" pinfunction="A8" pintype="input"/>
+      <node ref="U_DRAM5" pin="M2" pinfunction="A8" pintype="input"/>
+      <node ref="U_DRAM6" pin="M2" pinfunction="A8" pintype="input"/>
+      <node ref="U_DRAM7" pin="M2" pinfunction="A8" pintype="input"/>
+    </net>
+    <net code="14" name="A9" class="Default">
+      <node ref="J1" pin="66" pinfunction="A9" pintype="passive"/>
+      <node ref="J_HOST" pin="21" pinfunction="Pin_21" pintype="passive"/>
+      <node ref="U_DRAM0" pin="M7" pinfunction="A9" pintype="input"/>
+      <node ref="U_DRAM1" pin="M7" pinfunction="A9" pintype="input"/>
+      <node ref="U_DRAM2" pin="M7" pinfunction="A9" pintype="input"/>
+      <node ref="U_DRAM3" pin="M7" pinfunction="A9" pintype="input"/>
+      <node ref="U_DRAM4" pin="M7" pinfunction="A9" pintype="input"/>
+      <node ref="U_DRAM5" pin="M7" pinfunction="A9" pintype="input"/>
+      <node ref="U_DRAM6" pin="M7" pinfunction="A9" pintype="input"/>
+      <node ref="U_DRAM7" pin="M7" pinfunction="A9" pintype="input"/>
+    </net>
+    <net code="15" name="A10" class="Default">
+      <node ref="J1" pin="225" pinfunction="A10/AP" pintype="passive"/>
+      <node ref="J_HOST" pin="22" pinfunction="Pin_22" pintype="passive"/>
+      <node ref="U_DRAM0" pin="J3" pinfunction="A10/AP" pintype="input"/>
+      <node ref="U_DRAM1" pin="J3" pinfunction="A10/AP" pintype="input"/>
+      <node ref="U_DRAM2" pin="J3" pinfunction="A10/AP" pintype="input"/>
+      <node ref="U_DRAM3" pin="J3" pinfunction="A10/AP" pintype="input"/>
+      <node ref="U_DRAM4" pin="J3" pinfunction="A10/AP" pintype="input"/>
+      <node ref="U_DRAM5" pin="J3" pinfunction="A10/AP" pintype="input"/>
+      <node ref="U_DRAM6" pin="J3" pinfunction="A10/AP" pintype="input"/>
+      <node ref="U_DRAM7" pin="J3" pinfunction="A10/AP" pintype="input"/>
+    </net>
+    <net code="16" name="A11" class="Default">
+      <node ref="J1" pin="210" pinfunction="A11" pintype="passive"/>
+      <node ref="J_HOST" pin="23" pinfunction="Pin_23" pintype="passive"/>
+      <node ref="U_DRAM0" pin="N2" pinfunction="A11" pintype="input"/>
+      <node ref="U_DRAM1" pin="N2" pinfunction="A11" pintype="input"/>
+      <node ref="U_DRAM2" pin="N2" pinfunction="A11" pintype="input"/>
+      <node ref="U_DRAM3" pin="N2" pinfunction="A11" pintype="input"/>
+      <node ref="U_DRAM4" pin="N2" pinfunction="A11" pintype="input"/>
+      <node ref="U_DRAM5" pin="N2" pinfunction="A11" pintype="input"/>
+      <node ref="U_DRAM6" pin="N2" pinfunction="A11" pintype="input"/>
+      <node ref="U_DRAM7" pin="N2" pinfunction="A11" pintype="input"/>
+    </net>
+    <net code="17" name="A12" class="Default">
+      <node ref="J1" pin="65" pinfunction="A12/BC_n" pintype="passive"/>
+      <node ref="J_HOST" pin="24" pinfunction="Pin_24" pintype="passive"/>
+      <node ref="U_DRAM0" pin="J7" pinfunction="A12/~{BC}" pintype="input"/>
+      <node ref="U_DRAM1" pin="J7" pinfunction="A12/~{BC}" pintype="input"/>
+      <node ref="U_DRAM2" pin="J7" pinfunction="A12/~{BC}" pintype="input"/>
+      <node ref="U_DRAM3" pin="J7" pinfunction="A12/~{BC}" pintype="input"/>
+      <node ref="U_DRAM4" pin="J7" pinfunction="A12/~{BC}" pintype="input"/>
+      <node ref="U_DRAM5" pin="J7" pinfunction="A12/~{BC}" pintype="input"/>
+      <node ref="U_DRAM6" pin="J7" pinfunction="A12/~{BC}" pintype="input"/>
+      <node ref="U_DRAM7" pin="J7" pinfunction="A12/~{BC}" pintype="input"/>
+    </net>
+    <net code="18" name="A13" class="Default">
+      <node ref="J1" pin="232" pinfunction="A13" pintype="passive"/>
+      <node ref="J_HOST" pin="25" pinfunction="Pin_25" pintype="passive"/>
+      <node ref="U_DRAM0" pin="N8" pinfunction="A13" pintype="input"/>
+      <node ref="U_DRAM1" pin="N8" pinfunction="A13" pintype="input"/>
+      <node ref="U_DRAM2" pin="N8" pinfunction="A13" pintype="input"/>
+      <node ref="U_DRAM3" pin="N8" pinfunction="A13" pintype="input"/>
+      <node ref="U_DRAM4" pin="N8" pinfunction="A13" pintype="input"/>
+      <node ref="U_DRAM5" pin="N8" pinfunction="A13" pintype="input"/>
+      <node ref="U_DRAM6" pin="N8" pinfunction="A13" pintype="input"/>
+      <node ref="U_DRAM7" pin="N8" pinfunction="A13" pintype="input"/>
+    </net>
+    <net code="19" name="A14" class="Default">
+      <node ref="J1" pin="228" pinfunction="WE_n/A14" pintype="passive"/>
+      <node ref="J_HOST" pin="26" pinfunction="Pin_26" pintype="passive"/>
+      <node ref="U_DRAM0" pin="H2" pinfunction="A14/~{WE}" pintype="input"/>
+      <node ref="U_DRAM1" pin="H2" pinfunction="A14/~{WE}" pintype="input"/>
+      <node ref="U_DRAM2" pin="H2" pinfunction="A14/~{WE}" pintype="input"/>
+      <node ref="U_DRAM3" pin="H2" pinfunction="A14/~{WE}" pintype="input"/>
+      <node ref="U_DRAM4" pin="H2" pinfunction="A14/~{WE}" pintype="input"/>
+      <node ref="U_DRAM5" pin="H2" pinfunction="A14/~{WE}" pintype="input"/>
+      <node ref="U_DRAM6" pin="H2" pinfunction="A14/~{WE}" pintype="input"/>
+      <node ref="U_DRAM7" pin="H2" pinfunction="A14/~{WE}" pintype="input"/>
+    </net>
+    <net code="20" name="A15" class="Default">
+      <node ref="J1" pin="86" pinfunction="CAS_n/A15" pintype="passive"/>
+      <node ref="J_HOST" pin="27" pinfunction="Pin_27" pintype="passive"/>
+      <node ref="U_DRAM0" pin="H7" pinfunction="A15/~{CAS}" pintype="input"/>
+      <node ref="U_DRAM1" pin="H7" pinfunction="A15/~{CAS}" pintype="input"/>
+      <node ref="U_DRAM2" pin="H7" pinfunction="A15/~{CAS}" pintype="input"/>
+      <node ref="U_DRAM3" pin="H7" pinfunction="A15/~{CAS}" pintype="input"/>
+      <node ref="U_DRAM4" pin="H7" pinfunction="A15/~{CAS}" pintype="input"/>
+      <node ref="U_DRAM5" pin="H7" pinfunction="A15/~{CAS}" pintype="input"/>
+      <node ref="U_DRAM6" pin="H7" pinfunction="A15/~{CAS}" pintype="input"/>
+      <node ref="U_DRAM7" pin="H7" pinfunction="A15/~{CAS}" pintype="input"/>
+    </net>
+    <net code="21" name="A16" class="Default">
+      <node ref="J1" pin="82" pinfunction="RAS_n/A16" pintype="passive"/>
+      <node ref="J_HOST" pin="28" pinfunction="Pin_28" pintype="passive"/>
+      <node ref="U_DRAM0" pin="H8" pinfunction="A16/~{RAS}" pintype="input"/>
+      <node ref="U_DRAM1" pin="H8" pinfunction="A16/~{RAS}" pintype="input"/>
+      <node ref="U_DRAM2" pin="H8" pinfunction="A16/~{RAS}" pintype="input"/>
+      <node ref="U_DRAM3" pin="H8" pinfunction="A16/~{RAS}" pintype="input"/>
+      <node ref="U_DRAM4" pin="H8" pinfunction="A16/~{RAS}" pintype="input"/>
+      <node ref="U_DRAM5" pin="H8" pinfunction="A16/~{RAS}" pintype="input"/>
+      <node ref="U_DRAM6" pin="H8" pinfunction="A16/~{RAS}" pintype="input"/>
+      <node ref="U_DRAM7" pin="H8" pinfunction="A16/~{RAS}" pintype="input"/>
+    </net>
+    <net code="22" name="A17" class="Default">
+      <node ref="J_HOST" pin="29" pinfunction="Pin_29" pintype="passive"/>
+      <node ref="U_DRAM0" pin="N7" pinfunction="A17/NC" pintype="passive"/>
+      <node ref="U_DRAM1" pin="N7" pinfunction="A17/NC" pintype="passive"/>
+      <node ref="U_DRAM2" pin="N7" pinfunction="A17/NC" pintype="passive"/>
+      <node ref="U_DRAM3" pin="N7" pinfunction="A17/NC" pintype="passive"/>
+      <node ref="U_DRAM4" pin="N7" pinfunction="A17/NC" pintype="passive"/>
+      <node ref="U_DRAM5" pin="N7" pinfunction="A17/NC" pintype="passive"/>
+      <node ref="U_DRAM6" pin="N7" pinfunction="A17/NC" pintype="passive"/>
+      <node ref="U_DRAM7" pin="N7" pinfunction="A17/NC" pintype="passive"/>
+    </net>
+    <net code="23" name="ACT_n" class="Default">
+      <node ref="J1" pin="62" pinfunction="ACT_n" pintype="passive"/>
+      <node ref="J_HOST" pin="6" pinfunction="Pin_6" pintype="passive"/>
+      <node ref="U_DRAM0" pin="H3" pinfunction="~{ACT}" pintype="input"/>
+      <node ref="U_DRAM1" pin="H3" pinfunction="~{ACT}" pintype="input"/>
+      <node ref="U_DRAM2" pin="H3" pinfunction="~{ACT}" pintype="input"/>
+      <node ref="U_DRAM3" pin="H3" pinfunction="~{ACT}" pintype="input"/>
+      <node ref="U_DRAM4" pin="H3" pinfunction="~{ACT}" pintype="input"/>
+      <node ref="U_DRAM5" pin="H3" pinfunction="~{ACT}" pintype="input"/>
+      <node ref="U_DRAM6" pin="H3" pinfunction="~{ACT}" pintype="input"/>
+      <node ref="U_DRAM7" pin="H3" pinfunction="~{ACT}" pintype="input"/>
+    </net>
+    <net code="24" name="ALERT_n" class="Default">
+      <node ref="J1" pin="208" pinfunction="ALERT_n" pintype="passive"/>
+    </net>
+    <net code="25" name="BA0" class="Default">
+      <node ref="J1" pin="81" pinfunction="BA0" pintype="passive"/>
+      <node ref="J_HOST" pin="8" pinfunction="Pin_8" pintype="passive"/>
+      <node ref="U_DRAM0" pin="K2" pinfunction="BA0" pintype="input"/>
+      <node ref="U_DRAM1" pin="K2" pinfunction="BA0" pintype="input"/>
+      <node ref="U_DRAM2" pin="K2" pinfunction="BA0" pintype="input"/>
+      <node ref="U_DRAM3" pin="K2" pinfunction="BA0" pintype="input"/>
+      <node ref="U_DRAM4" pin="K2" pinfunction="BA0" pintype="input"/>
+      <node ref="U_DRAM5" pin="K2" pinfunction="BA0" pintype="input"/>
+      <node ref="U_DRAM6" pin="K2" pinfunction="BA0" pintype="input"/>
+      <node ref="U_DRAM7" pin="K2" pinfunction="BA0" pintype="input"/>
+    </net>
+    <net code="26" name="BA1" class="Default">
+      <node ref="J1" pin="224" pinfunction="BA1" pintype="passive"/>
+      <node ref="J_HOST" pin="9" pinfunction="Pin_9" pintype="passive"/>
+      <node ref="U_DRAM0" pin="K8" pinfunction="BA1" pintype="input"/>
+      <node ref="U_DRAM1" pin="K8" pinfunction="BA1" pintype="input"/>
+      <node ref="U_DRAM2" pin="K8" pinfunction="BA1" pintype="input"/>
+      <node ref="U_DRAM3" pin="K8" pinfunction="BA1" pintype="input"/>
+      <node ref="U_DRAM4" pin="K8" pinfunction="BA1" pintype="input"/>
+      <node ref="U_DRAM5" pin="K8" pinfunction="BA1" pintype="input"/>
+      <node ref="U_DRAM6" pin="K8" pinfunction="BA1" pintype="input"/>
+      <node ref="U_DRAM7" pin="K8" pinfunction="BA1" pintype="input"/>
+    </net>
+    <net code="27" name="BG0" class="Default">
+      <node ref="J1" pin="63" pinfunction="BG0" pintype="passive"/>
+      <node ref="J_HOST" pin="10" pinfunction="Pin_10" pintype="passive"/>
+      <node ref="U_DRAM0" pin="J2" pinfunction="BG0" pintype="input"/>
+      <node ref="U_DRAM1" pin="J2" pinfunction="BG0" pintype="input"/>
+      <node ref="U_DRAM2" pin="J2" pinfunction="BG0" pintype="input"/>
+      <node ref="U_DRAM3" pin="J2" pinfunction="BG0" pintype="input"/>
+      <node ref="U_DRAM4" pin="J2" pinfunction="BG0" pintype="input"/>
+      <node ref="U_DRAM5" pin="J2" pinfunction="BG0" pintype="input"/>
+      <node ref="U_DRAM6" pin="J2" pinfunction="BG0" pintype="input"/>
+      <node ref="U_DRAM7" pin="J2" pinfunction="BG0" pintype="input"/>
+    </net>
+    <net code="28" name="BG1" class="Default">
+      <node ref="J1" pin="207" pinfunction="BG1" pintype="passive"/>
+      <node ref="J_HOST" pin="11" pinfunction="Pin_11" pintype="passive"/>
+      <node ref="U_DRAM0" pin="J8" pinfunction="BG1" pintype="input"/>
+      <node ref="U_DRAM1" pin="J8" pinfunction="BG1" pintype="input"/>
+      <node ref="U_DRAM2" pin="J8" pinfunction="BG1" pintype="input"/>
+      <node ref="U_DRAM3" pin="J8" pinfunction="BG1" pintype="input"/>
+      <node ref="U_DRAM4" pin="J8" pinfunction="BG1" pintype="input"/>
+      <node ref="U_DRAM5" pin="J8" pinfunction="BG1" pintype="input"/>
+      <node ref="U_DRAM6" pin="J8" pinfunction="BG1" pintype="input"/>
+      <node ref="U_DRAM7" pin="J8" pinfunction="BG1" pintype="input"/>
+    </net>
+    <net code="29" name="CKE0" class="Default">
+      <node ref="J1" pin="60" pinfunction="CKE0" pintype="passive"/>
+      <node ref="J_HOST" pin="5" pinfunction="Pin_5" pintype="passive"/>
+      <node ref="U_DRAM0" pin="G3" pinfunction="CKE" pintype="input"/>
+      <node ref="U_DRAM1" pin="G3" pinfunction="CKE" pintype="input"/>
+      <node ref="U_DRAM2" pin="G3" pinfunction="CKE" pintype="input"/>
+      <node ref="U_DRAM3" pin="G3" pinfunction="CKE" pintype="input"/>
+      <node ref="U_DRAM4" pin="G3" pinfunction="CKE" pintype="input"/>
+      <node ref="U_DRAM5" pin="G3" pinfunction="CKE" pintype="input"/>
+      <node ref="U_DRAM6" pin="G3" pinfunction="CKE" pintype="input"/>
+      <node ref="U_DRAM7" pin="G3" pinfunction="CKE" pintype="input"/>
+    </net>
+    <net code="30" name="CK_c" class="Default">
+      <node ref="J1" pin="75" pinfunction="CK0_c" pintype="passive"/>
+      <node ref="J_HOST" pin="2" pinfunction="Pin_2" pintype="passive"/>
+      <node ref="U_DRAM0" pin="F8" pinfunction="CK_c" pintype="input"/>
+      <node ref="U_DRAM1" pin="F8" pinfunction="CK_c" pintype="input"/>
+      <node ref="U_DRAM2" pin="F8" pinfunction="CK_c" pintype="input"/>
+      <node ref="U_DRAM3" pin="F8" pinfunction="CK_c" pintype="input"/>
+      <node ref="U_DRAM4" pin="F8" pinfunction="CK_c" pintype="input"/>
+      <node ref="U_DRAM5" pin="F8" pinfunction="CK_c" pintype="input"/>
+      <node ref="U_DRAM6" pin="F8" pinfunction="CK_c" pintype="input"/>
+      <node ref="U_DRAM7" pin="F8" pinfunction="CK_c" pintype="input"/>
+    </net>
+    <net code="31" name="CK_t" class="Default">
+      <node ref="J1" pin="74" pinfunction="CK0_t" pintype="passive"/>
+      <node ref="J_HOST" pin="1" pinfunction="Pin_1" pintype="passive"/>
+      <node ref="U_DRAM0" pin="F7" pinfunction="CK_t" pintype="input"/>
+      <node ref="U_DRAM1" pin="F7" pinfunction="CK_t" pintype="input"/>
+      <node ref="U_DRAM2" pin="F7" pinfunction="CK_t" pintype="input"/>
+      <node ref="U_DRAM3" pin="F7" pinfunction="CK_t" pintype="input"/>
+      <node ref="U_DRAM4" pin="F7" pinfunction="CK_t" pintype="input"/>
+      <node ref="U_DRAM5" pin="F7" pinfunction="CK_t" pintype="input"/>
+      <node ref="U_DRAM6" pin="F7" pinfunction="CK_t" pintype="input"/>
+      <node ref="U_DRAM7" pin="F7" pinfunction="CK_t" pintype="input"/>
+    </net>
+    <net code="32" name="CS0_n" class="Default">
+      <node ref="J1" pin="84" pinfunction="CS0_n" pintype="passive"/>
+      <node ref="J_HOST" pin="4" pinfunction="Pin_4" pintype="passive"/>
+      <node ref="U_DRAM0" pin="G7" pinfunction="~{CS}" pintype="input"/>
+      <node ref="U_DRAM1" pin="G7" pinfunction="~{CS}" pintype="input"/>
+      <node ref="U_DRAM2" pin="G7" pinfunction="~{CS}" pintype="input"/>
+      <node ref="U_DRAM3" pin="G7" pinfunction="~{CS}" pintype="input"/>
+      <node ref="U_DRAM4" pin="G7" pinfunction="~{CS}" pintype="input"/>
+      <node ref="U_DRAM5" pin="G7" pinfunction="~{CS}" pintype="input"/>
+      <node ref="U_DRAM6" pin="G7" pinfunction="~{CS}" pintype="input"/>
+      <node ref="U_DRAM7" pin="G7" pinfunction="~{CS}" pintype="input"/>
+    </net>
+    <net code="33" name="D0_DM_DBI_n" class="Default">
+      <node ref="J1" pin="7" pinfunction="DM0_n/DBI0_n" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="11" pinfunction="Pin_11" pintype="passive"/>
+      <node ref="U_DRAM0" pin="A7" pinfunction="TDQS_t/~{DM/DBI}" pintype="bidirectional"/>
+    </net>
+    <net code="34" name="D0_DQ0" class="Default">
+      <node ref="J1" pin="5" pinfunction="DQ0" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="1" pinfunction="Pin_1" pintype="passive"/>
+      <node ref="U_DRAM0" pin="C2" pinfunction="DQ0" pintype="bidirectional"/>
+    </net>
+    <net code="35" name="D0_DQ1" class="Default">
+      <node ref="J1" pin="150" pinfunction="DQ1" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="2" pinfunction="Pin_2" pintype="passive"/>
+      <node ref="U_DRAM0" pin="B7" pinfunction="DQ1" pintype="bidirectional"/>
+    </net>
+    <net code="36" name="D0_DQ2" class="Default">
+      <node ref="J1" pin="12" pinfunction="DQ2" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="3" pinfunction="Pin_3" pintype="passive"/>
+      <node ref="U_DRAM0" pin="D3" pinfunction="DQ2" pintype="bidirectional"/>
+    </net>
+    <net code="37" name="D0_DQ3" class="Default">
+      <node ref="J1" pin="157" pinfunction="DQ3" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="4" pinfunction="Pin_4" pintype="passive"/>
+      <node ref="U_DRAM0" pin="D7" pinfunction="DQ3" pintype="bidirectional"/>
+    </net>
+    <net code="38" name="D0_DQ4" class="Default">
+      <node ref="J1" pin="3" pinfunction="DQ4" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="5" pinfunction="Pin_5" pintype="passive"/>
+      <node ref="U_DRAM0" pin="D2" pinfunction="DQ4" pintype="bidirectional"/>
+    </net>
+    <net code="39" name="D0_DQ5" class="Default">
+      <node ref="J1" pin="148" pinfunction="DQ5" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="6" pinfunction="Pin_6" pintype="passive"/>
+      <node ref="U_DRAM0" pin="D8" pinfunction="DQ5" pintype="bidirectional"/>
+    </net>
+    <net code="40" name="D0_DQ6" class="Default">
+      <node ref="J1" pin="10" pinfunction="DQ6" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="7" pinfunction="Pin_7" pintype="passive"/>
+      <node ref="U_DRAM0" pin="E3" pinfunction="DQ6" pintype="bidirectional"/>
+    </net>
+    <net code="41" name="D0_DQ7" class="Default">
+      <node ref="J1" pin="155" pinfunction="DQ7" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="8" pinfunction="Pin_8" pintype="passive"/>
+      <node ref="U_DRAM0" pin="E7" pinfunction="DQ7" pintype="bidirectional"/>
+    </net>
+    <net code="42" name="D0_DQS_c" class="Default">
+      <node ref="J1" pin="152" pinfunction="DQS0_c" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="10" pinfunction="Pin_10" pintype="passive"/>
+      <node ref="U_DRAM0" pin="B3" pinfunction="DQS_c" pintype="bidirectional"/>
+    </net>
+    <net code="43" name="D0_DQS_t" class="Default">
+      <node ref="J1" pin="153" pinfunction="DQS0_t" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="9" pinfunction="Pin_9" pintype="passive"/>
+      <node ref="U_DRAM0" pin="C3" pinfunction="DQS_t" pintype="bidirectional"/>
+    </net>
+    <net code="44" name="D1_DM_DBI_n" class="Default">
+      <node ref="J1" pin="18" pinfunction="DM1_n/DBI1_n" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="22" pinfunction="Pin_22" pintype="passive"/>
+      <node ref="U_DRAM1" pin="A7" pinfunction="TDQS_t/~{DM/DBI}" pintype="bidirectional"/>
+    </net>
+    <net code="45" name="D1_DQ0" class="Default">
+      <node ref="J1" pin="16" pinfunction="DQ8" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="12" pinfunction="Pin_12" pintype="passive"/>
+      <node ref="U_DRAM1" pin="C2" pinfunction="DQ0" pintype="bidirectional"/>
+    </net>
+    <net code="46" name="D1_DQ1" class="Default">
+      <node ref="J1" pin="161" pinfunction="DQ9" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="13" pinfunction="Pin_13" pintype="passive"/>
+      <node ref="U_DRAM1" pin="B7" pinfunction="DQ1" pintype="bidirectional"/>
+    </net>
+    <net code="47" name="D1_DQ2" class="Default">
+      <node ref="J1" pin="23" pinfunction="DQ10" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="14" pinfunction="Pin_14" pintype="passive"/>
+      <node ref="U_DRAM1" pin="D3" pinfunction="DQ2" pintype="bidirectional"/>
+    </net>
+    <net code="48" name="D1_DQ3" class="Default">
+      <node ref="J1" pin="168" pinfunction="DQ11" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="15" pinfunction="Pin_15" pintype="passive"/>
+      <node ref="U_DRAM1" pin="D7" pinfunction="DQ3" pintype="bidirectional"/>
+    </net>
+    <net code="49" name="D1_DQ4" class="Default">
+      <node ref="J1" pin="14" pinfunction="DQ12" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="16" pinfunction="Pin_16" pintype="passive"/>
+      <node ref="U_DRAM1" pin="D2" pinfunction="DQ4" pintype="bidirectional"/>
+    </net>
+    <net code="50" name="D1_DQ5" class="Default">
+      <node ref="J1" pin="159" pinfunction="DQ13" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="17" pinfunction="Pin_17" pintype="passive"/>
+      <node ref="U_DRAM1" pin="D8" pinfunction="DQ5" pintype="bidirectional"/>
+    </net>
+    <net code="51" name="D1_DQ6" class="Default">
+      <node ref="J1" pin="21" pinfunction="DQ14" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="18" pinfunction="Pin_18" pintype="passive"/>
+      <node ref="U_DRAM1" pin="E3" pinfunction="DQ6" pintype="bidirectional"/>
+    </net>
+    <net code="52" name="D1_DQ7" class="Default">
+      <node ref="J1" pin="166" pinfunction="DQ15" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="19" pinfunction="Pin_19" pintype="passive"/>
+      <node ref="U_DRAM1" pin="E7" pinfunction="DQ7" pintype="bidirectional"/>
+    </net>
+    <net code="53" name="D1_DQS_c" class="Default">
+      <node ref="J1" pin="163" pinfunction="DQS1_c" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="21" pinfunction="Pin_21" pintype="passive"/>
+      <node ref="U_DRAM1" pin="B3" pinfunction="DQS_c" pintype="bidirectional"/>
+    </net>
+    <net code="54" name="D1_DQS_t" class="Default">
+      <node ref="J1" pin="164" pinfunction="DQS1_t" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="20" pinfunction="Pin_20" pintype="passive"/>
+      <node ref="U_DRAM1" pin="C3" pinfunction="DQS_t" pintype="bidirectional"/>
+    </net>
+    <net code="55" name="D2_DM_DBI_n" class="Default">
+      <node ref="J1" pin="29" pinfunction="DM2_n/DBI2_n" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="33" pinfunction="Pin_33" pintype="passive"/>
+      <node ref="U_DRAM2" pin="A7" pinfunction="TDQS_t/~{DM/DBI}" pintype="bidirectional"/>
+    </net>
+    <net code="56" name="D2_DQ0" class="Default">
+      <node ref="J1" pin="27" pinfunction="DQ16" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="23" pinfunction="Pin_23" pintype="passive"/>
+      <node ref="U_DRAM2" pin="C2" pinfunction="DQ0" pintype="bidirectional"/>
+    </net>
+    <net code="57" name="D2_DQ1" class="Default">
+      <node ref="J1" pin="172" pinfunction="DQ17" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="24" pinfunction="Pin_24" pintype="passive"/>
+      <node ref="U_DRAM2" pin="B7" pinfunction="DQ1" pintype="bidirectional"/>
+    </net>
+    <net code="58" name="D2_DQ2" class="Default">
+      <node ref="J1" pin="34" pinfunction="DQ18" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="25" pinfunction="Pin_25" pintype="passive"/>
+      <node ref="U_DRAM2" pin="D3" pinfunction="DQ2" pintype="bidirectional"/>
+    </net>
+    <net code="59" name="D2_DQ3" class="Default">
+      <node ref="J1" pin="179" pinfunction="DQ19" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="26" pinfunction="Pin_26" pintype="passive"/>
+      <node ref="U_DRAM2" pin="D7" pinfunction="DQ3" pintype="bidirectional"/>
+    </net>
+    <net code="60" name="D2_DQ4" class="Default">
+      <node ref="J1" pin="25" pinfunction="DQ20" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="27" pinfunction="Pin_27" pintype="passive"/>
+      <node ref="U_DRAM2" pin="D2" pinfunction="DQ4" pintype="bidirectional"/>
+    </net>
+    <net code="61" name="D2_DQ5" class="Default">
+      <node ref="J1" pin="170" pinfunction="DQ21" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="28" pinfunction="Pin_28" pintype="passive"/>
+      <node ref="U_DRAM2" pin="D8" pinfunction="DQ5" pintype="bidirectional"/>
+    </net>
+    <net code="62" name="D2_DQ6" class="Default">
+      <node ref="J1" pin="32" pinfunction="DQ22" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="29" pinfunction="Pin_29" pintype="passive"/>
+      <node ref="U_DRAM2" pin="E3" pinfunction="DQ6" pintype="bidirectional"/>
+    </net>
+    <net code="63" name="D2_DQ7" class="Default">
+      <node ref="J1" pin="177" pinfunction="DQ23" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="30" pinfunction="Pin_30" pintype="passive"/>
+      <node ref="U_DRAM2" pin="E7" pinfunction="DQ7" pintype="bidirectional"/>
+    </net>
+    <net code="64" name="D2_DQS_c" class="Default">
+      <node ref="J1" pin="174" pinfunction="DQS2_c" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="32" pinfunction="Pin_32" pintype="passive"/>
+      <node ref="U_DRAM2" pin="B3" pinfunction="DQS_c" pintype="bidirectional"/>
+    </net>
+    <net code="65" name="D2_DQS_t" class="Default">
+      <node ref="J1" pin="175" pinfunction="DQS2_t" pintype="passive"/>
+      <node ref="J_HOST_DQ_A" pin="31" pinfunction="Pin_31" pintype="passive"/>
+      <node ref="U_DRAM2" pin="C3" pinfunction="DQS_t" pintype="bidirectional"/>
+    </net>
+    <net code="66" name="D3_DM_DBI_n" class="Default">
+      <node ref="J1" pin="40" pinfunction="DM3_n/DBI3_n" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="11" pinfunction="Pin_11" pintype="passive"/>
+      <node ref="U_DRAM3" pin="A7" pinfunction="TDQS_t/~{DM/DBI}" pintype="bidirectional"/>
+    </net>
+    <net code="67" name="D3_DQ0" class="Default">
+      <node ref="J1" pin="38" pinfunction="DQ24" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="1" pinfunction="Pin_1" pintype="passive"/>
+      <node ref="U_DRAM3" pin="C2" pinfunction="DQ0" pintype="bidirectional"/>
+    </net>
+    <net code="68" name="D3_DQ1" class="Default">
+      <node ref="J1" pin="183" pinfunction="DQ25" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="2" pinfunction="Pin_2" pintype="passive"/>
+      <node ref="U_DRAM3" pin="B7" pinfunction="DQ1" pintype="bidirectional"/>
+    </net>
+    <net code="69" name="D3_DQ2" class="Default">
+      <node ref="J1" pin="45" pinfunction="DQ26" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="3" pinfunction="Pin_3" pintype="passive"/>
+      <node ref="U_DRAM3" pin="D3" pinfunction="DQ2" pintype="bidirectional"/>
+    </net>
+    <net code="70" name="D3_DQ3" class="Default">
+      <node ref="J1" pin="190" pinfunction="DQ27" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="4" pinfunction="Pin_4" pintype="passive"/>
+      <node ref="U_DRAM3" pin="D7" pinfunction="DQ3" pintype="bidirectional"/>
+    </net>
+    <net code="71" name="D3_DQ4" class="Default">
+      <node ref="J1" pin="36" pinfunction="DQ28" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="5" pinfunction="Pin_5" pintype="passive"/>
+      <node ref="U_DRAM3" pin="D2" pinfunction="DQ4" pintype="bidirectional"/>
+    </net>
+    <net code="72" name="D3_DQ5" class="Default">
+      <node ref="J1" pin="181" pinfunction="DQ29" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="6" pinfunction="Pin_6" pintype="passive"/>
+      <node ref="U_DRAM3" pin="D8" pinfunction="DQ5" pintype="bidirectional"/>
+    </net>
+    <net code="73" name="D3_DQ6" class="Default">
+      <node ref="J1" pin="43" pinfunction="DQ30" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="7" pinfunction="Pin_7" pintype="passive"/>
+      <node ref="U_DRAM3" pin="E3" pinfunction="DQ6" pintype="bidirectional"/>
+    </net>
+    <net code="74" name="D3_DQ7" class="Default">
+      <node ref="J1" pin="188" pinfunction="DQ31" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="8" pinfunction="Pin_8" pintype="passive"/>
+      <node ref="U_DRAM3" pin="E7" pinfunction="DQ7" pintype="bidirectional"/>
+    </net>
+    <net code="75" name="D3_DQS_c" class="Default">
+      <node ref="J1" pin="185" pinfunction="DQS3_c" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="10" pinfunction="Pin_10" pintype="passive"/>
+      <node ref="U_DRAM3" pin="B3" pinfunction="DQS_c" pintype="bidirectional"/>
+    </net>
+    <net code="76" name="D3_DQS_t" class="Default">
+      <node ref="J1" pin="186" pinfunction="DQS3_t" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="9" pinfunction="Pin_9" pintype="passive"/>
+      <node ref="U_DRAM3" pin="C3" pinfunction="DQS_t" pintype="bidirectional"/>
+    </net>
+    <net code="77" name="D4_DM_DBI_n" class="Default">
+      <node ref="J1" pin="99" pinfunction="DM4_n/DBI4_n" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="22" pinfunction="Pin_22" pintype="passive"/>
+      <node ref="U_DRAM4" pin="A7" pinfunction="TDQS_t/~{DM/DBI}" pintype="bidirectional"/>
+    </net>
+    <net code="78" name="D4_DQ0" class="Default">
+      <node ref="J1" pin="97" pinfunction="DQ32" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="12" pinfunction="Pin_12" pintype="passive"/>
+      <node ref="U_DRAM4" pin="C2" pinfunction="DQ0" pintype="bidirectional"/>
+    </net>
+    <net code="79" name="D4_DQ1" class="Default">
+      <node ref="J1" pin="242" pinfunction="DQ33" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="13" pinfunction="Pin_13" pintype="passive"/>
+      <node ref="U_DRAM4" pin="B7" pinfunction="DQ1" pintype="bidirectional"/>
+    </net>
+    <net code="80" name="D4_DQ2" class="Default">
+      <node ref="J1" pin="104" pinfunction="DQ34" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="14" pinfunction="Pin_14" pintype="passive"/>
+      <node ref="U_DRAM4" pin="D3" pinfunction="DQ2" pintype="bidirectional"/>
+    </net>
+    <net code="81" name="D4_DQ3" class="Default">
+      <node ref="J1" pin="249" pinfunction="DQ35" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="15" pinfunction="Pin_15" pintype="passive"/>
+      <node ref="U_DRAM4" pin="D7" pinfunction="DQ3" pintype="bidirectional"/>
+    </net>
+    <net code="82" name="D4_DQ4" class="Default">
+      <node ref="J1" pin="95" pinfunction="DQ36" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="16" pinfunction="Pin_16" pintype="passive"/>
+      <node ref="U_DRAM4" pin="D2" pinfunction="DQ4" pintype="bidirectional"/>
+    </net>
+    <net code="83" name="D4_DQ5" class="Default">
+      <node ref="J1" pin="240" pinfunction="DQ37" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="17" pinfunction="Pin_17" pintype="passive"/>
+      <node ref="U_DRAM4" pin="D8" pinfunction="DQ5" pintype="bidirectional"/>
+    </net>
+    <net code="84" name="D4_DQ6" class="Default">
+      <node ref="J1" pin="102" pinfunction="DQ38" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="18" pinfunction="Pin_18" pintype="passive"/>
+      <node ref="U_DRAM4" pin="E3" pinfunction="DQ6" pintype="bidirectional"/>
+    </net>
+    <net code="85" name="D4_DQ7" class="Default">
+      <node ref="J1" pin="247" pinfunction="DQ39" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="19" pinfunction="Pin_19" pintype="passive"/>
+      <node ref="U_DRAM4" pin="E7" pinfunction="DQ7" pintype="bidirectional"/>
+    </net>
+    <net code="86" name="D4_DQS_c" class="Default">
+      <node ref="J1" pin="244" pinfunction="DQS4_c" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="21" pinfunction="Pin_21" pintype="passive"/>
+      <node ref="U_DRAM4" pin="B3" pinfunction="DQS_c" pintype="bidirectional"/>
+    </net>
+    <net code="87" name="D4_DQS_t" class="Default">
+      <node ref="J1" pin="245" pinfunction="DQS4_t" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="20" pinfunction="Pin_20" pintype="passive"/>
+      <node ref="U_DRAM4" pin="C3" pinfunction="DQS_t" pintype="bidirectional"/>
+    </net>
+    <net code="88" name="D5_DM_DBI_n" class="Default">
+      <node ref="J1" pin="110" pinfunction="DM5_n/DBI5_n" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="33" pinfunction="Pin_33" pintype="passive"/>
+      <node ref="U_DRAM5" pin="A7" pinfunction="TDQS_t/~{DM/DBI}" pintype="bidirectional"/>
+    </net>
+    <net code="89" name="D5_DQ0" class="Default">
+      <node ref="J1" pin="108" pinfunction="DQ40" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="23" pinfunction="Pin_23" pintype="passive"/>
+      <node ref="U_DRAM5" pin="C2" pinfunction="DQ0" pintype="bidirectional"/>
+    </net>
+    <net code="90" name="D5_DQ1" class="Default">
+      <node ref="J1" pin="253" pinfunction="DQ41" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="24" pinfunction="Pin_24" pintype="passive"/>
+      <node ref="U_DRAM5" pin="B7" pinfunction="DQ1" pintype="bidirectional"/>
+    </net>
+    <net code="91" name="D5_DQ2" class="Default">
+      <node ref="J1" pin="115" pinfunction="DQ42" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="25" pinfunction="Pin_25" pintype="passive"/>
+      <node ref="U_DRAM5" pin="D3" pinfunction="DQ2" pintype="bidirectional"/>
+    </net>
+    <net code="92" name="D5_DQ3" class="Default">
+      <node ref="J1" pin="260" pinfunction="DQ43" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="26" pinfunction="Pin_26" pintype="passive"/>
+      <node ref="U_DRAM5" pin="D7" pinfunction="DQ3" pintype="bidirectional"/>
+    </net>
+    <net code="93" name="D5_DQ4" class="Default">
+      <node ref="J1" pin="106" pinfunction="DQ44" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="27" pinfunction="Pin_27" pintype="passive"/>
+      <node ref="U_DRAM5" pin="D2" pinfunction="DQ4" pintype="bidirectional"/>
+    </net>
+    <net code="94" name="D5_DQ5" class="Default">
+      <node ref="J1" pin="251" pinfunction="DQ45" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="28" pinfunction="Pin_28" pintype="passive"/>
+      <node ref="U_DRAM5" pin="D8" pinfunction="DQ5" pintype="bidirectional"/>
+    </net>
+    <net code="95" name="D5_DQ6" class="Default">
+      <node ref="J1" pin="113" pinfunction="DQ46" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="29" pinfunction="Pin_29" pintype="passive"/>
+      <node ref="U_DRAM5" pin="E3" pinfunction="DQ6" pintype="bidirectional"/>
+    </net>
+    <net code="96" name="D5_DQ7" class="Default">
+      <node ref="J1" pin="258" pinfunction="DQ47" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="30" pinfunction="Pin_30" pintype="passive"/>
+      <node ref="U_DRAM5" pin="E7" pinfunction="DQ7" pintype="bidirectional"/>
+    </net>
+    <net code="97" name="D5_DQS_c" class="Default">
+      <node ref="J1" pin="255" pinfunction="DQS5_c" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="32" pinfunction="Pin_32" pintype="passive"/>
+      <node ref="U_DRAM5" pin="B3" pinfunction="DQS_c" pintype="bidirectional"/>
+    </net>
+    <net code="98" name="D5_DQS_t" class="Default">
+      <node ref="J1" pin="256" pinfunction="DQS5_t" pintype="passive"/>
+      <node ref="J_HOST_DQ_B" pin="31" pinfunction="Pin_31" pintype="passive"/>
+      <node ref="U_DRAM5" pin="C3" pinfunction="DQS_t" pintype="bidirectional"/>
+    </net>
+    <net code="99" name="D6_DM_DBI_n" class="Default">
+      <node ref="J1" pin="121" pinfunction="DM6_n/DBI6_n" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="11" pinfunction="Pin_11" pintype="passive"/>
+      <node ref="U_DRAM6" pin="A7" pinfunction="TDQS_t/~{DM/DBI}" pintype="bidirectional"/>
+    </net>
+    <net code="100" name="D6_DQ0" class="Default">
+      <node ref="J1" pin="119" pinfunction="DQ48" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="1" pinfunction="Pin_1" pintype="passive"/>
+      <node ref="U_DRAM6" pin="C2" pinfunction="DQ0" pintype="bidirectional"/>
+    </net>
+    <net code="101" name="D6_DQ1" class="Default">
+      <node ref="J1" pin="264" pinfunction="DQ49" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="2" pinfunction="Pin_2" pintype="passive"/>
+      <node ref="U_DRAM6" pin="B7" pinfunction="DQ1" pintype="bidirectional"/>
+    </net>
+    <net code="102" name="D6_DQ2" class="Default">
+      <node ref="J1" pin="126" pinfunction="DQ50" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="3" pinfunction="Pin_3" pintype="passive"/>
+      <node ref="U_DRAM6" pin="D3" pinfunction="DQ2" pintype="bidirectional"/>
+    </net>
+    <net code="103" name="D6_DQ3" class="Default">
+      <node ref="J1" pin="271" pinfunction="DQ51" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="4" pinfunction="Pin_4" pintype="passive"/>
+      <node ref="U_DRAM6" pin="D7" pinfunction="DQ3" pintype="bidirectional"/>
+    </net>
+    <net code="104" name="D6_DQ4" class="Default">
+      <node ref="J1" pin="117" pinfunction="DQ52" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="5" pinfunction="Pin_5" pintype="passive"/>
+      <node ref="U_DRAM6" pin="D2" pinfunction="DQ4" pintype="bidirectional"/>
+    </net>
+    <net code="105" name="D6_DQ5" class="Default">
+      <node ref="J1" pin="262" pinfunction="DQ53" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="6" pinfunction="Pin_6" pintype="passive"/>
+      <node ref="U_DRAM6" pin="D8" pinfunction="DQ5" pintype="bidirectional"/>
+    </net>
+    <net code="106" name="D6_DQ6" class="Default">
+      <node ref="J1" pin="124" pinfunction="DQ54" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="7" pinfunction="Pin_7" pintype="passive"/>
+      <node ref="U_DRAM6" pin="E3" pinfunction="DQ6" pintype="bidirectional"/>
+    </net>
+    <net code="107" name="D6_DQ7" class="Default">
+      <node ref="J1" pin="269" pinfunction="DQ55" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="8" pinfunction="Pin_8" pintype="passive"/>
+      <node ref="U_DRAM6" pin="E7" pinfunction="DQ7" pintype="bidirectional"/>
+    </net>
+    <net code="108" name="D6_DQS_c" class="Default">
+      <node ref="J1" pin="266" pinfunction="DQS6_c" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="10" pinfunction="Pin_10" pintype="passive"/>
+      <node ref="U_DRAM6" pin="B3" pinfunction="DQS_c" pintype="bidirectional"/>
+    </net>
+    <net code="109" name="D6_DQS_t" class="Default">
+      <node ref="J1" pin="267" pinfunction="DQS6_t" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="9" pinfunction="Pin_9" pintype="passive"/>
+      <node ref="U_DRAM6" pin="C3" pinfunction="DQS_t" pintype="bidirectional"/>
+    </net>
+    <net code="110" name="D7_DM_DBI_n" class="Default">
+      <node ref="J1" pin="132" pinfunction="DM7_n/DBI7_n" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="22" pinfunction="Pin_22" pintype="passive"/>
+      <node ref="U_DRAM7" pin="A7" pinfunction="TDQS_t/~{DM/DBI}" pintype="bidirectional"/>
+    </net>
+    <net code="111" name="D7_DQ0" class="Default">
+      <node ref="J1" pin="130" pinfunction="DQ56" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="12" pinfunction="Pin_12" pintype="passive"/>
+      <node ref="U_DRAM7" pin="C2" pinfunction="DQ0" pintype="bidirectional"/>
+    </net>
+    <net code="112" name="D7_DQ1" class="Default">
+      <node ref="J1" pin="275" pinfunction="DQ57" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="13" pinfunction="Pin_13" pintype="passive"/>
+      <node ref="U_DRAM7" pin="B7" pinfunction="DQ1" pintype="bidirectional"/>
+    </net>
+    <net code="113" name="D7_DQ2" class="Default">
+      <node ref="J1" pin="137" pinfunction="DQ58" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="14" pinfunction="Pin_14" pintype="passive"/>
+      <node ref="U_DRAM7" pin="D3" pinfunction="DQ2" pintype="bidirectional"/>
+    </net>
+    <net code="114" name="D7_DQ3" class="Default">
+      <node ref="J1" pin="282" pinfunction="DQ59" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="15" pinfunction="Pin_15" pintype="passive"/>
+      <node ref="U_DRAM7" pin="D7" pinfunction="DQ3" pintype="bidirectional"/>
+    </net>
+    <net code="115" name="D7_DQ4" class="Default">
+      <node ref="J1" pin="128" pinfunction="DQ60" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="16" pinfunction="Pin_16" pintype="passive"/>
+      <node ref="U_DRAM7" pin="D2" pinfunction="DQ4" pintype="bidirectional"/>
+    </net>
+    <net code="116" name="D7_DQ5" class="Default">
+      <node ref="J1" pin="273" pinfunction="DQ61" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="17" pinfunction="Pin_17" pintype="passive"/>
+      <node ref="U_DRAM7" pin="D8" pinfunction="DQ5" pintype="bidirectional"/>
+    </net>
+    <net code="117" name="D7_DQ6" class="Default">
+      <node ref="J1" pin="135" pinfunction="DQ62" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="18" pinfunction="Pin_18" pintype="passive"/>
+      <node ref="U_DRAM7" pin="E3" pinfunction="DQ6" pintype="bidirectional"/>
+    </net>
+    <net code="118" name="D7_DQ7" class="Default">
+      <node ref="J1" pin="280" pinfunction="DQ63" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="19" pinfunction="Pin_19" pintype="passive"/>
+      <node ref="U_DRAM7" pin="E7" pinfunction="DQ7" pintype="bidirectional"/>
+    </net>
+    <net code="119" name="D7_DQS_c" class="Default">
+      <node ref="J1" pin="277" pinfunction="DQS7_c" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="21" pinfunction="Pin_21" pintype="passive"/>
+      <node ref="U_DRAM7" pin="B3" pinfunction="DQS_c" pintype="bidirectional"/>
+    </net>
+    <net code="120" name="D7_DQS_t" class="Default">
+      <node ref="J1" pin="278" pinfunction="DQS7_t" pintype="passive"/>
+      <node ref="J_HOST_DQ_C" pin="20" pinfunction="Pin_20" pintype="passive"/>
+      <node ref="U_DRAM7" pin="C3" pinfunction="DQS_t" pintype="bidirectional"/>
+    </net>
+    <net code="121" name="GND" class="Default">
+      <node ref="J1" pin="101" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="103" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="105" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="107" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="109" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="11" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="112" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="114" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="116" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="118" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="120" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="123" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="125" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="127" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="129" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="13" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="131" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="134" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="136" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="138" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="147" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="149" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="15" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="151" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="154" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="156" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="158" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="160" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="162" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="165" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="167" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="169" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="17" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="171" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="173" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="176" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="178" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="180" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="182" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="184" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="187" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="189" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="191" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="193" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="195" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="198" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="2" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="20" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="200" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="202" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="22" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="24" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="241" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="243" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="246" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="248" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="250" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="252" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="254" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="257" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="259" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="26" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="261" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="263" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="265" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="268" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="270" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="272" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="274" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="276" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="279" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="28" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="281" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="283" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="31" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="33" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="35" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="37" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="39" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="4" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="42" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="44" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="46" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="48" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="50" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="53" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="55" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="57" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="6" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="9" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="94" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="96" pinfunction="VSS" pintype="passive"/>
+      <node ref="J1" pin="98" pinfunction="VSS" pintype="passive"/>
+      <node ref="J_HOST_SPD" pin="2" pinfunction="Pin_2" pintype="passive"/>
+      <node ref="J_PWR" pin="5" pinfunction="Pin_5" pintype="passive"/>
+      <node ref="U_DRAM0" pin="A2" pinfunction="VSSQ" pintype="power_in"/>
+      <node ref="U_DRAM0" pin="A8" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM0" pin="A9" pinfunction="VSS" pintype="power_in"/>
+      <node ref="U_DRAM0" pin="C8" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM0" pin="D1" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM0" pin="D9" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM0" pin="E1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM0" pin="E9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM0" pin="G1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM0" pin="H9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM0" pin="K1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM0" pin="K9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM0" pin="N1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM1" pin="A2" pinfunction="VSSQ" pintype="power_in"/>
+      <node ref="U_DRAM1" pin="A8" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM1" pin="A9" pinfunction="VSS" pintype="power_in"/>
+      <node ref="U_DRAM1" pin="C8" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM1" pin="D1" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM1" pin="D9" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM1" pin="E1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM1" pin="E9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM1" pin="G1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM1" pin="H9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM1" pin="K1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM1" pin="K9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM1" pin="N1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM2" pin="A2" pinfunction="VSSQ" pintype="power_in"/>
+      <node ref="U_DRAM2" pin="A8" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM2" pin="A9" pinfunction="VSS" pintype="power_in"/>
+      <node ref="U_DRAM2" pin="C8" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM2" pin="D1" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM2" pin="D9" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM2" pin="E1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM2" pin="E9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM2" pin="G1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM2" pin="H9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM2" pin="K1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM2" pin="K9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM2" pin="N1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM3" pin="A2" pinfunction="VSSQ" pintype="power_in"/>
+      <node ref="U_DRAM3" pin="A8" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM3" pin="A9" pinfunction="VSS" pintype="power_in"/>
+      <node ref="U_DRAM3" pin="C8" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM3" pin="D1" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM3" pin="D9" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM3" pin="E1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM3" pin="E9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM3" pin="G1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM3" pin="H9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM3" pin="K1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM3" pin="K9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM3" pin="N1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM4" pin="A2" pinfunction="VSSQ" pintype="power_in"/>
+      <node ref="U_DRAM4" pin="A8" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM4" pin="A9" pinfunction="VSS" pintype="power_in"/>
+      <node ref="U_DRAM4" pin="C8" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM4" pin="D1" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM4" pin="D9" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM4" pin="E1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM4" pin="E9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM4" pin="G1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM4" pin="H9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM4" pin="K1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM4" pin="K9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM4" pin="N1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM5" pin="A2" pinfunction="VSSQ" pintype="power_in"/>
+      <node ref="U_DRAM5" pin="A8" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM5" pin="A9" pinfunction="VSS" pintype="power_in"/>
+      <node ref="U_DRAM5" pin="C8" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM5" pin="D1" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM5" pin="D9" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM5" pin="E1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM5" pin="E9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM5" pin="G1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM5" pin="H9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM5" pin="K1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM5" pin="K9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM5" pin="N1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM6" pin="A2" pinfunction="VSSQ" pintype="power_in"/>
+      <node ref="U_DRAM6" pin="A8" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM6" pin="A9" pinfunction="VSS" pintype="power_in"/>
+      <node ref="U_DRAM6" pin="C8" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM6" pin="D1" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM6" pin="D9" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM6" pin="E1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM6" pin="E9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM6" pin="G1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM6" pin="H9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM6" pin="K1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM6" pin="K9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM6" pin="N1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM7" pin="A2" pinfunction="VSSQ" pintype="power_in"/>
+      <node ref="U_DRAM7" pin="A8" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM7" pin="A9" pinfunction="VSS" pintype="power_in"/>
+      <node ref="U_DRAM7" pin="C8" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM7" pin="D1" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM7" pin="D9" pinfunction="VSSQ" pintype="passive"/>
+      <node ref="U_DRAM7" pin="E1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM7" pin="E9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM7" pin="G1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM7" pin="H9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM7" pin="K1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM7" pin="K9" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_DRAM7" pin="N1" pinfunction="VSS" pintype="passive"/>
+      <node ref="U_SPD0" pin="4" pinfunction="GND" pintype="power_in"/>
+      <node ref="U_SPD0" pin="7" pinfunction="WP" pintype="input"/>
+      <node ref="U_SPD0" pin="9" pinfunction="GND" pintype="passive"/>
+    </net>
+    <net code="122" name="ODT0" class="Default">
+      <node ref="J1" pin="87" pinfunction="ODT0" pintype="passive"/>
+      <node ref="J_HOST" pin="7" pinfunction="Pin_7" pintype="passive"/>
+      <node ref="U_DRAM0" pin="F3" pinfunction="ODT" pintype="input"/>
+      <node ref="U_DRAM1" pin="F3" pinfunction="ODT" pintype="input"/>
+      <node ref="U_DRAM2" pin="F3" pinfunction="ODT" pintype="input"/>
+      <node ref="U_DRAM3" pin="F3" pinfunction="ODT" pintype="input"/>
+      <node ref="U_DRAM4" pin="F3" pinfunction="ODT" pintype="input"/>
+      <node ref="U_DRAM5" pin="F3" pinfunction="ODT" pintype="input"/>
+      <node ref="U_DRAM6" pin="F3" pinfunction="ODT" pintype="input"/>
+      <node ref="U_DRAM7" pin="F3" pinfunction="ODT" pintype="input"/>
+    </net>
+    <net code="123" name="PARITY" class="Default">
+      <node ref="J1" pin="222" pinfunction="PARITY" pintype="passive"/>
+    </net>
+    <net code="124" name="RESET_n" class="Default">
+      <node ref="J1" pin="58" pinfunction="RESET_n" pintype="passive"/>
+      <node ref="J_HOST" pin="3" pinfunction="Pin_3" pintype="passive"/>
+      <node ref="U_DRAM0" pin="L1" pinfunction="~{RESET}" pintype="input"/>
+      <node ref="U_DRAM1" pin="L1" pinfunction="~{RESET}" pintype="input"/>
+      <node ref="U_DRAM2" pin="L1" pinfunction="~{RESET}" pintype="input"/>
+      <node ref="U_DRAM3" pin="L1" pinfunction="~{RESET}" pintype="input"/>
+      <node ref="U_DRAM4" pin="L1" pinfunction="~{RESET}" pintype="input"/>
+      <node ref="U_DRAM5" pin="L1" pinfunction="~{RESET}" pintype="input"/>
+      <node ref="U_DRAM6" pin="L1" pinfunction="~{RESET}" pintype="input"/>
+      <node ref="U_DRAM7" pin="L1" pinfunction="~{RESET}" pintype="input"/>
+    </net>
+    <net code="125" name="SA0" class="Default">
+      <node ref="J1" pin="139" pinfunction="SA0" pintype="passive"/>
+      <node ref="J_HOST_SPD" pin="5" pinfunction="Pin_5" pintype="passive"/>
+      <node ref="U_SPD0" pin="1" pinfunction="A0" pintype="input"/>
+    </net>
+    <net code="126" name="SA1" class="Default">
+      <node ref="J1" pin="140" pinfunction="SA1" pintype="passive"/>
+      <node ref="J_HOST_SPD" pin="6" pinfunction="Pin_6" pintype="passive"/>
+      <node ref="U_SPD0" pin="2" pinfunction="A1" pintype="input"/>
+    </net>
+    <net code="127" name="SA2" class="Default">
+      <node ref="J1" pin="238" pinfunction="SA2" pintype="passive"/>
+      <node ref="J_HOST_SPD" pin="7" pinfunction="Pin_7" pintype="passive"/>
+      <node ref="U_SPD0" pin="3" pinfunction="A2" pintype="input"/>
+    </net>
+    <net code="128" name="SPD_SCL" class="Default">
+      <node ref="J1" pin="141" pinfunction="SCL" pintype="passive"/>
+      <node ref="J_HOST_SPD" pin="3" pinfunction="Pin_3" pintype="passive"/>
+      <node ref="U_SPD0" pin="6" pinfunction="SCL" pintype="input"/>
+    </net>
+    <net code="129" name="SPD_SDA" class="Default">
+      <node ref="J1" pin="285" pinfunction="SDA" pintype="passive"/>
+      <node ref="J_HOST_SPD" pin="4" pinfunction="Pin_4" pintype="passive"/>
+      <node ref="U_SPD0" pin="5" pinfunction="SDA" pintype="bidirectional"/>
+    </net>
+    <net code="130" name="VDD" class="Default">
+      <node ref="J1" pin="204" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="206" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="209" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="212" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="215" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="217" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="220" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="223" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="226" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="229" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="231" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="233" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="236" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="239" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="59" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="61" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="64" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="67" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="70" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="73" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="76" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="80" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="83" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="85" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="88" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="90" pinfunction="VDD" pintype="passive"/>
+      <node ref="J1" pin="92" pinfunction="VDD" pintype="passive"/>
+      <node ref="J_PWR" pin="1" pinfunction="Pin_1" pintype="passive"/>
+      <node ref="U_DRAM0" pin="A1" pinfunction="VDD" pintype="power_in"/>
+      <node ref="U_DRAM0" pin="C7" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM0" pin="F1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM0" pin="F9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM0" pin="H1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM0" pin="J9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM0" pin="M1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM0" pin="N9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM1" pin="A1" pinfunction="VDD" pintype="power_in"/>
+      <node ref="U_DRAM1" pin="C7" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM1" pin="F1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM1" pin="F9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM1" pin="H1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM1" pin="J9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM1" pin="M1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM1" pin="N9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM2" pin="A1" pinfunction="VDD" pintype="power_in"/>
+      <node ref="U_DRAM2" pin="C7" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM2" pin="F1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM2" pin="F9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM2" pin="H1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM2" pin="J9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM2" pin="M1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM2" pin="N9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM3" pin="A1" pinfunction="VDD" pintype="power_in"/>
+      <node ref="U_DRAM3" pin="C7" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM3" pin="F1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM3" pin="F9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM3" pin="H1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM3" pin="J9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM3" pin="M1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM3" pin="N9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM4" pin="A1" pinfunction="VDD" pintype="power_in"/>
+      <node ref="U_DRAM4" pin="C7" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM4" pin="F1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM4" pin="F9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM4" pin="H1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM4" pin="J9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM4" pin="M1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM4" pin="N9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM5" pin="A1" pinfunction="VDD" pintype="power_in"/>
+      <node ref="U_DRAM5" pin="C7" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM5" pin="F1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM5" pin="F9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM5" pin="H1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM5" pin="J9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM5" pin="M1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM5" pin="N9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM6" pin="A1" pinfunction="VDD" pintype="power_in"/>
+      <node ref="U_DRAM6" pin="C7" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM6" pin="F1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM6" pin="F9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM6" pin="H1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM6" pin="J9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM6" pin="M1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM6" pin="N9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM7" pin="A1" pinfunction="VDD" pintype="power_in"/>
+      <node ref="U_DRAM7" pin="C7" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM7" pin="F1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM7" pin="F9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM7" pin="H1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM7" pin="J9" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM7" pin="M1" pinfunction="VDD" pintype="passive"/>
+      <node ref="U_DRAM7" pin="N9" pinfunction="VDD" pintype="passive"/>
+    </net>
+    <net code="131" name="VDDSPD" class="Default">
+      <node ref="J1" pin="284" pinfunction="VDDSPD" pintype="passive"/>
+      <node ref="J_HOST_SPD" pin="1" pinfunction="Pin_1" pintype="passive"/>
+      <node ref="U_SPD0" pin="8" pinfunction="VCC" pintype="power_in"/>
+    </net>
+    <net code="132" name="VPP" class="Default">
+      <node ref="J1" pin="142" pinfunction="VPP" pintype="passive"/>
+      <node ref="J1" pin="143" pinfunction="VPP" pintype="passive"/>
+      <node ref="J1" pin="286" pinfunction="VPP" pintype="passive"/>
+      <node ref="J1" pin="287" pinfunction="VPP" pintype="passive"/>
+      <node ref="J1" pin="288" pinfunction="VPP" pintype="passive"/>
+      <node ref="J_PWR" pin="3" pinfunction="Pin_3" pintype="passive"/>
+      <node ref="U_DRAM0" pin="B1" pinfunction="VPP" pintype="power_in"/>
+      <node ref="U_DRAM0" pin="M9" pinfunction="VPP" pintype="passive"/>
+      <node ref="U_DRAM1" pin="B1" pinfunction="VPP" pintype="power_in"/>
+      <node ref="U_DRAM1" pin="M9" pinfunction="VPP" pintype="passive"/>
+      <node ref="U_DRAM2" pin="B1" pinfunction="VPP" pintype="power_in"/>
+      <node ref="U_DRAM2" pin="M9" pinfunction="VPP" pintype="passive"/>
+      <node ref="U_DRAM3" pin="B1" pinfunction="VPP" pintype="power_in"/>
+      <node ref="U_DRAM3" pin="M9" pinfunction="VPP" pintype="passive"/>
+      <node ref="U_DRAM4" pin="B1" pinfunction="VPP" pintype="power_in"/>
+      <node ref="U_DRAM4" pin="M9" pinfunction="VPP" pintype="passive"/>
+      <node ref="U_DRAM5" pin="B1" pinfunction="VPP" pintype="power_in"/>
+      <node ref="U_DRAM5" pin="M9" pinfunction="VPP" pintype="passive"/>
+      <node ref="U_DRAM6" pin="B1" pinfunction="VPP" pintype="power_in"/>
+      <node ref="U_DRAM6" pin="M9" pinfunction="VPP" pintype="passive"/>
+      <node ref="U_DRAM7" pin="B1" pinfunction="VPP" pintype="power_in"/>
+      <node ref="U_DRAM7" pin="M9" pinfunction="VPP" pintype="passive"/>
+    </net>
+    <net code="133" name="VREF" class="Default">
+      <node ref="J1" pin="146" pinfunction="VREFCA" pintype="passive"/>
+    </net>
+    <net code="134" name="VTT" class="Default">
+      <node ref="J1" pin="221" pinfunction="VTT" pintype="passive"/>
+      <node ref="J1" pin="77" pinfunction="VTT" pintype="passive"/>
+    </net>
+    <net code="135" name="unconnected-(J1-CB0/NC-Pad49)" class="Default">
+      <node ref="J1" pin="49" pinfunction="CB0/NC" pintype="no_connect"/>
+    </net>
+    <net code="136" name="unconnected-(J1-CB1/NC-Pad194)" class="Default">
+      <node ref="J1" pin="194" pinfunction="CB1/NC" pintype="no_connect"/>
+    </net>
+    <net code="137" name="unconnected-(J1-CB2/NC-Pad56)" class="Default">
+      <node ref="J1" pin="56" pinfunction="CB2/NC" pintype="no_connect"/>
+    </net>
+    <net code="138" name="unconnected-(J1-CB3/NC-Pad201)" class="Default">
+      <node ref="J1" pin="201" pinfunction="CB3/NC" pintype="no_connect"/>
+    </net>
+    <net code="139" name="unconnected-(J1-CB4/NC-Pad47)" class="Default">
+      <node ref="J1" pin="47" pinfunction="CB4/NC" pintype="no_connect"/>
+    </net>
+    <net code="140" name="unconnected-(J1-CB5/NC-Pad192)" class="Default">
+      <node ref="J1" pin="192" pinfunction="CB5/NC" pintype="no_connect"/>
+    </net>
+    <net code="141" name="unconnected-(J1-CB6/DBI8_n-Pad54)" class="Default">
+      <node ref="J1" pin="54" pinfunction="CB6/DBI8_n" pintype="no_connect"/>
+    </net>
+    <net code="142" name="unconnected-(J1-CB7/NC-Pad199)" class="Default">
+      <node ref="J1" pin="199" pinfunction="CB7/NC" pintype="no_connect"/>
+    </net>
+    <net code="143" name="unconnected-(J1-CK1_c-Pad219)" class="Default">
+      <node ref="J1" pin="219" pinfunction="CK1_c" pintype="no_connect"/>
+    </net>
+    <net code="144" name="unconnected-(J1-CK1_t-Pad218)" class="Default">
+      <node ref="J1" pin="218" pinfunction="CK1_t" pintype="no_connect"/>
+    </net>
+    <net code="145" name="unconnected-(J1-CKE1-Pad203)" class="Default">
+      <node ref="J1" pin="203" pinfunction="CKE1" pintype="no_connect"/>
+    </net>
+    <net code="146" name="unconnected-(J1-CS1_n-Pad89)" class="Default">
+      <node ref="J1" pin="89" pinfunction="CS1_n" pintype="no_connect"/>
+    </net>
+    <net code="147" name="unconnected-(J1-DM8_n/DBI8_n-Pad51)" class="Default">
+      <node ref="J1" pin="51" pinfunction="DM8_n/DBI8_n" pintype="no_connect"/>
+    </net>
+    <net code="148" name="unconnected-(J1-DQS8_c-Pad196)" class="Default">
+      <node ref="J1" pin="196" pinfunction="DQS8_c" pintype="no_connect"/>
+    </net>
+    <net code="149" name="unconnected-(J1-DQS8_t-Pad197)" class="Default">
+      <node ref="J1" pin="197" pinfunction="DQS8_t" pintype="no_connect"/>
+    </net>
+    <net code="150" name="unconnected-(J1-EVENT_n-Pad78)" class="Default">
+      <node ref="J1" pin="78" pinfunction="EVENT_n" pintype="no_connect"/>
+    </net>
+    <net code="151" name="unconnected-(J1-NC-Pad1)" class="Default">
+      <node ref="J1" pin="1" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="152" name="unconnected-(J1-NC-Pad8)" class="Default">
+      <node ref="J1" pin="8" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="153" name="unconnected-(J1-NC-Pad19)" class="Default">
+      <node ref="J1" pin="19" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="154" name="unconnected-(J1-NC-Pad30)" class="Default">
+      <node ref="J1" pin="30" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="155" name="unconnected-(J1-NC-Pad41)" class="Default">
+      <node ref="J1" pin="41" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="156" name="unconnected-(J1-NC-Pad52)" class="Default">
+      <node ref="J1" pin="52" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="157" name="unconnected-(J1-NC-Pad93)" class="Default">
+      <node ref="J1" pin="93" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="158" name="unconnected-(J1-NC-Pad100)" class="Default">
+      <node ref="J1" pin="100" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="159" name="unconnected-(J1-NC-Pad111)" class="Default">
+      <node ref="J1" pin="111" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="160" name="unconnected-(J1-NC-Pad122)" class="Default">
+      <node ref="J1" pin="122" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="161" name="unconnected-(J1-NC-Pad133)" class="Default">
+      <node ref="J1" pin="133" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="162" name="unconnected-(J1-NC-Pad144)" class="Default">
+      <node ref="J1" pin="144" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="163" name="unconnected-(J1-NC-Pad145)" class="Default">
+      <node ref="J1" pin="145" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="164" name="unconnected-(J1-NC-Pad205)" class="Default">
+      <node ref="J1" pin="205" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="165" name="unconnected-(J1-NC-Pad227)" class="Default">
+      <node ref="J1" pin="227" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="166" name="unconnected-(J1-NC-Pad230)" class="Default">
+      <node ref="J1" pin="230" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="167" name="unconnected-(J1-NC-Pad234)" class="Default">
+      <node ref="J1" pin="234" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="168" name="unconnected-(J1-NC-Pad235)" class="Default">
+      <node ref="J1" pin="235" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="169" name="unconnected-(J1-NC-Pad237)" class="Default">
+      <node ref="J1" pin="237" pinfunction="NC" pintype="no_connect"/>
+    </net>
+    <net code="170" name="unconnected-(J1-ODT1-Pad91)" class="Default">
+      <node ref="J1" pin="91" pinfunction="ODT1" pintype="no_connect"/>
+    </net>
+    <net code="171" name="unconnected-(J_HOST-Pin_30-Pad30)" class="Default">
+      <node ref="J_HOST" pin="30" pinfunction="Pin_30" pintype="passive"/>
+    </net>
+    <net code="172" name="unconnected-(J_HOST-Pin_31-Pad31)" class="Default">
+      <node ref="J_HOST" pin="31" pinfunction="Pin_31" pintype="passive"/>
+    </net>
+    <net code="173" name="unconnected-(J_HOST-Pin_32-Pad32)" class="Default">
+      <node ref="J_HOST" pin="32" pinfunction="Pin_32" pintype="passive"/>
+    </net>
+    <net code="174" name="unconnected-(J_HOST-Pin_33-Pad33)" class="Default">
+      <node ref="J_HOST" pin="33" pinfunction="Pin_33" pintype="passive"/>
+    </net>
+    <net code="175" name="unconnected-(J_HOST-Pin_34-Pad34)" class="Default">
+      <node ref="J_HOST" pin="34" pinfunction="Pin_34" pintype="passive"/>
+    </net>
+    <net code="176" name="unconnected-(J_HOST-Pin_35-Pad35)" class="Default">
+      <node ref="J_HOST" pin="35" pinfunction="Pin_35" pintype="passive"/>
+    </net>
+    <net code="177" name="unconnected-(J_HOST-Pin_36-Pad36)" class="Default">
+      <node ref="J_HOST" pin="36" pinfunction="Pin_36" pintype="passive"/>
+    </net>
+    <net code="178" name="unconnected-(J_HOST-Pin_37-Pad37)" class="Default">
+      <node ref="J_HOST" pin="37" pinfunction="Pin_37" pintype="passive"/>
+    </net>
+    <net code="179" name="unconnected-(J_HOST-Pin_38-Pad38)" class="Default">
+      <node ref="J_HOST" pin="38" pinfunction="Pin_38" pintype="passive"/>
+    </net>
+    <net code="180" name="unconnected-(J_HOST-Pin_39-Pad39)" class="Default">
+      <node ref="J_HOST" pin="39" pinfunction="Pin_39" pintype="passive"/>
+    </net>
+    <net code="181" name="unconnected-(J_HOST-Pin_40-Pad40)" class="Default">
+      <node ref="J_HOST" pin="40" pinfunction="Pin_40" pintype="passive"/>
+    </net>
+    <net code="182" name="unconnected-(J_HOST_DQ_A-Pin_34-Pad34)" class="Default">
+      <node ref="J_HOST_DQ_A" pin="34" pinfunction="Pin_34" pintype="passive"/>
+    </net>
+    <net code="183" name="unconnected-(J_HOST_DQ_A-Pin_35-Pad35)" class="Default">
+      <node ref="J_HOST_DQ_A" pin="35" pinfunction="Pin_35" pintype="passive"/>
+    </net>
+    <net code="184" name="unconnected-(J_HOST_DQ_A-Pin_36-Pad36)" class="Default">
+      <node ref="J_HOST_DQ_A" pin="36" pinfunction="Pin_36" pintype="passive"/>
+    </net>
+    <net code="185" name="unconnected-(J_HOST_DQ_A-Pin_37-Pad37)" class="Default">
+      <node ref="J_HOST_DQ_A" pin="37" pinfunction="Pin_37" pintype="passive"/>
+    </net>
+    <net code="186" name="unconnected-(J_HOST_DQ_A-Pin_38-Pad38)" class="Default">
+      <node ref="J_HOST_DQ_A" pin="38" pinfunction="Pin_38" pintype="passive"/>
+    </net>
+    <net code="187" name="unconnected-(J_HOST_DQ_A-Pin_39-Pad39)" class="Default">
+      <node ref="J_HOST_DQ_A" pin="39" pinfunction="Pin_39" pintype="passive"/>
+    </net>
+    <net code="188" name="unconnected-(J_HOST_DQ_A-Pin_40-Pad40)" class="Default">
+      <node ref="J_HOST_DQ_A" pin="40" pinfunction="Pin_40" pintype="passive"/>
+    </net>
+    <net code="189" name="unconnected-(J_HOST_DQ_B-Pin_34-Pad34)" class="Default">
+      <node ref="J_HOST_DQ_B" pin="34" pinfunction="Pin_34" pintype="passive"/>
+    </net>
+    <net code="190" name="unconnected-(J_HOST_DQ_B-Pin_35-Pad35)" class="Default">
+      <node ref="J_HOST_DQ_B" pin="35" pinfunction="Pin_35" pintype="passive"/>
+    </net>
+    <net code="191" name="unconnected-(J_HOST_DQ_B-Pin_36-Pad36)" class="Default">
+      <node ref="J_HOST_DQ_B" pin="36" pinfunction="Pin_36" pintype="passive"/>
+    </net>
+    <net code="192" name="unconnected-(J_HOST_DQ_B-Pin_37-Pad37)" class="Default">
+      <node ref="J_HOST_DQ_B" pin="37" pinfunction="Pin_37" pintype="passive"/>
+    </net>
+    <net code="193" name="unconnected-(J_HOST_DQ_B-Pin_38-Pad38)" class="Default">
+      <node ref="J_HOST_DQ_B" pin="38" pinfunction="Pin_38" pintype="passive"/>
+    </net>
+    <net code="194" name="unconnected-(J_HOST_DQ_B-Pin_39-Pad39)" class="Default">
+      <node ref="J_HOST_DQ_B" pin="39" pinfunction="Pin_39" pintype="passive"/>
+    </net>
+    <net code="195" name="unconnected-(J_HOST_DQ_B-Pin_40-Pad40)" class="Default">
+      <node ref="J_HOST_DQ_B" pin="40" pinfunction="Pin_40" pintype="passive"/>
+    </net>
+    <net code="196" name="unconnected-(J_HOST_DQ_C-Pin_23-Pad23)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="23" pinfunction="Pin_23" pintype="passive"/>
+    </net>
+    <net code="197" name="unconnected-(J_HOST_DQ_C-Pin_24-Pad24)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="24" pinfunction="Pin_24" pintype="passive"/>
+    </net>
+    <net code="198" name="unconnected-(J_HOST_DQ_C-Pin_25-Pad25)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="25" pinfunction="Pin_25" pintype="passive"/>
+    </net>
+    <net code="199" name="unconnected-(J_HOST_DQ_C-Pin_26-Pad26)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="26" pinfunction="Pin_26" pintype="passive"/>
+    </net>
+    <net code="200" name="unconnected-(J_HOST_DQ_C-Pin_27-Pad27)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="27" pinfunction="Pin_27" pintype="passive"/>
+    </net>
+    <net code="201" name="unconnected-(J_HOST_DQ_C-Pin_28-Pad28)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="28" pinfunction="Pin_28" pintype="passive"/>
+    </net>
+    <net code="202" name="unconnected-(J_HOST_DQ_C-Pin_29-Pad29)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="29" pinfunction="Pin_29" pintype="passive"/>
+    </net>
+    <net code="203" name="unconnected-(J_HOST_DQ_C-Pin_30-Pad30)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="30" pinfunction="Pin_30" pintype="passive"/>
+    </net>
+    <net code="204" name="unconnected-(J_HOST_DQ_C-Pin_31-Pad31)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="31" pinfunction="Pin_31" pintype="passive"/>
+    </net>
+    <net code="205" name="unconnected-(J_HOST_DQ_C-Pin_32-Pad32)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="32" pinfunction="Pin_32" pintype="passive"/>
+    </net>
+    <net code="206" name="unconnected-(J_HOST_DQ_C-Pin_33-Pad33)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="33" pinfunction="Pin_33" pintype="passive"/>
+    </net>
+    <net code="207" name="unconnected-(J_HOST_DQ_C-Pin_34-Pad34)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="34" pinfunction="Pin_34" pintype="passive"/>
+    </net>
+    <net code="208" name="unconnected-(J_HOST_DQ_C-Pin_35-Pad35)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="35" pinfunction="Pin_35" pintype="passive"/>
+    </net>
+    <net code="209" name="unconnected-(J_HOST_DQ_C-Pin_36-Pad36)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="36" pinfunction="Pin_36" pintype="passive"/>
+    </net>
+    <net code="210" name="unconnected-(J_HOST_DQ_C-Pin_37-Pad37)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="37" pinfunction="Pin_37" pintype="passive"/>
+    </net>
+    <net code="211" name="unconnected-(J_HOST_DQ_C-Pin_38-Pad38)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="38" pinfunction="Pin_38" pintype="passive"/>
+    </net>
+    <net code="212" name="unconnected-(J_HOST_DQ_C-Pin_39-Pad39)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="39" pinfunction="Pin_39" pintype="passive"/>
+    </net>
+    <net code="213" name="unconnected-(J_HOST_DQ_C-Pin_40-Pad40)" class="Default">
+      <node ref="J_HOST_DQ_C" pin="40" pinfunction="Pin_40" pintype="passive"/>
+    </net>
+    <net code="214" name="unconnected-(J_HOST_SPD-Pin_8-Pad8)" class="Default">
+      <node ref="J_HOST_SPD" pin="8" pinfunction="Pin_8" pintype="passive"/>
+    </net>
+    <net code="215" name="unconnected-(U_DRAM0-NC/C0/CKE1-PadG2)" class="Default">
+      <node ref="U_DRAM0" pin="G2" pinfunction="NC/C0/CKE1" pintype="passive"/>
+    </net>
+    <net code="216" name="unconnected-(U_DRAM0-NC/C1/~{CS1}-PadG8)" class="Default">
+      <node ref="U_DRAM0" pin="G8" pinfunction="NC/C1/~{CS1}" pintype="passive"/>
+    </net>
+    <net code="217" name="unconnected-(U_DRAM0-NC/C2/ODT1-PadF2)" class="Default">
+      <node ref="U_DRAM0" pin="F2" pinfunction="NC/C2/ODT1" pintype="passive"/>
+    </net>
+    <net code="218" name="unconnected-(U_DRAM0-PAR-PadN3)" class="Default">
+      <node ref="U_DRAM0" pin="N3" pinfunction="PAR" pintype="input"/>
+    </net>
+    <net code="219" name="unconnected-(U_DRAM0-TDQS_c-PadA3)" class="Default">
+      <node ref="U_DRAM0" pin="A3" pinfunction="TDQS_c" pintype="output"/>
+    </net>
+    <net code="220" name="unconnected-(U_DRAM0-TEN-PadG9)" class="Default">
+      <node ref="U_DRAM0" pin="G9" pinfunction="TEN" pintype="input"/>
+    </net>
+    <net code="221" name="unconnected-(U_DRAM0-ZQ-PadB9)" class="Default">
+      <node ref="U_DRAM0" pin="B9" pinfunction="ZQ" pintype="passive"/>
+    </net>
+    <net code="222" name="unconnected-(U_DRAM0-~{ALERT}-PadL9)" class="Default">
+      <node ref="U_DRAM0" pin="L9" pinfunction="~{ALERT}" pintype="open_collector"/>
+    </net>
+    <net code="223" name="unconnected-(U_DRAM1-NC/C0/CKE1-PadG2)" class="Default">
+      <node ref="U_DRAM1" pin="G2" pinfunction="NC/C0/CKE1" pintype="passive"/>
+    </net>
+    <net code="224" name="unconnected-(U_DRAM1-NC/C1/~{CS1}-PadG8)" class="Default">
+      <node ref="U_DRAM1" pin="G8" pinfunction="NC/C1/~{CS1}" pintype="passive"/>
+    </net>
+    <net code="225" name="unconnected-(U_DRAM1-NC/C2/ODT1-PadF2)" class="Default">
+      <node ref="U_DRAM1" pin="F2" pinfunction="NC/C2/ODT1" pintype="passive"/>
+    </net>
+    <net code="226" name="unconnected-(U_DRAM1-PAR-PadN3)" class="Default">
+      <node ref="U_DRAM1" pin="N3" pinfunction="PAR" pintype="input"/>
+    </net>
+    <net code="227" name="unconnected-(U_DRAM1-TDQS_c-PadA3)" class="Default">
+      <node ref="U_DRAM1" pin="A3" pinfunction="TDQS_c" pintype="output"/>
+    </net>
+    <net code="228" name="unconnected-(U_DRAM1-TEN-PadG9)" class="Default">
+      <node ref="U_DRAM1" pin="G9" pinfunction="TEN" pintype="input"/>
+    </net>
+    <net code="229" name="unconnected-(U_DRAM1-ZQ-PadB9)" class="Default">
+      <node ref="U_DRAM1" pin="B9" pinfunction="ZQ" pintype="passive"/>
+    </net>
+    <net code="230" name="unconnected-(U_DRAM1-~{ALERT}-PadL9)" class="Default">
+      <node ref="U_DRAM1" pin="L9" pinfunction="~{ALERT}" pintype="open_collector"/>
+    </net>
+    <net code="231" name="unconnected-(U_DRAM2-NC/C0/CKE1-PadG2)" class="Default">
+      <node ref="U_DRAM2" pin="G2" pinfunction="NC/C0/CKE1" pintype="passive"/>
+    </net>
+    <net code="232" name="unconnected-(U_DRAM2-NC/C1/~{CS1}-PadG8)" class="Default">
+      <node ref="U_DRAM2" pin="G8" pinfunction="NC/C1/~{CS1}" pintype="passive"/>
+    </net>
+    <net code="233" name="unconnected-(U_DRAM2-NC/C2/ODT1-PadF2)" class="Default">
+      <node ref="U_DRAM2" pin="F2" pinfunction="NC/C2/ODT1" pintype="passive"/>
+    </net>
+    <net code="234" name="unconnected-(U_DRAM2-PAR-PadN3)" class="Default">
+      <node ref="U_DRAM2" pin="N3" pinfunction="PAR" pintype="input"/>
+    </net>
+    <net code="235" name="unconnected-(U_DRAM2-TDQS_c-PadA3)" class="Default">
+      <node ref="U_DRAM2" pin="A3" pinfunction="TDQS_c" pintype="output"/>
+    </net>
+    <net code="236" name="unconnected-(U_DRAM2-TEN-PadG9)" class="Default">
+      <node ref="U_DRAM2" pin="G9" pinfunction="TEN" pintype="input"/>
+    </net>
+    <net code="237" name="unconnected-(U_DRAM2-ZQ-PadB9)" class="Default">
+      <node ref="U_DRAM2" pin="B9" pinfunction="ZQ" pintype="passive"/>
+    </net>
+    <net code="238" name="unconnected-(U_DRAM2-~{ALERT}-PadL9)" class="Default">
+      <node ref="U_DRAM2" pin="L9" pinfunction="~{ALERT}" pintype="open_collector"/>
+    </net>
+    <net code="239" name="unconnected-(U_DRAM3-NC/C0/CKE1-PadG2)" class="Default">
+      <node ref="U_DRAM3" pin="G2" pinfunction="NC/C0/CKE1" pintype="passive"/>
+    </net>
+    <net code="240" name="unconnected-(U_DRAM3-NC/C1/~{CS1}-PadG8)" class="Default">
+      <node ref="U_DRAM3" pin="G8" pinfunction="NC/C1/~{CS1}" pintype="passive"/>
+    </net>
+    <net code="241" name="unconnected-(U_DRAM3-NC/C2/ODT1-PadF2)" class="Default">
+      <node ref="U_DRAM3" pin="F2" pinfunction="NC/C2/ODT1" pintype="passive"/>
+    </net>
+    <net code="242" name="unconnected-(U_DRAM3-PAR-PadN3)" class="Default">
+      <node ref="U_DRAM3" pin="N3" pinfunction="PAR" pintype="input"/>
+    </net>
+    <net code="243" name="unconnected-(U_DRAM3-TDQS_c-PadA3)" class="Default">
+      <node ref="U_DRAM3" pin="A3" pinfunction="TDQS_c" pintype="output"/>
+    </net>
+    <net code="244" name="unconnected-(U_DRAM3-TEN-PadG9)" class="Default">
+      <node ref="U_DRAM3" pin="G9" pinfunction="TEN" pintype="input"/>
+    </net>
+    <net code="245" name="unconnected-(U_DRAM3-ZQ-PadB9)" class="Default">
+      <node ref="U_DRAM3" pin="B9" pinfunction="ZQ" pintype="passive"/>
+    </net>
+    <net code="246" name="unconnected-(U_DRAM3-~{ALERT}-PadL9)" class="Default">
+      <node ref="U_DRAM3" pin="L9" pinfunction="~{ALERT}" pintype="open_collector"/>
+    </net>
+    <net code="247" name="unconnected-(U_DRAM4-NC/C0/CKE1-PadG2)" class="Default">
+      <node ref="U_DRAM4" pin="G2" pinfunction="NC/C0/CKE1" pintype="passive"/>
+    </net>
+    <net code="248" name="unconnected-(U_DRAM4-NC/C1/~{CS1}-PadG8)" class="Default">
+      <node ref="U_DRAM4" pin="G8" pinfunction="NC/C1/~{CS1}" pintype="passive"/>
+    </net>
+    <net code="249" name="unconnected-(U_DRAM4-NC/C2/ODT1-PadF2)" class="Default">
+      <node ref="U_DRAM4" pin="F2" pinfunction="NC/C2/ODT1" pintype="passive"/>
+    </net>
+    <net code="250" name="unconnected-(U_DRAM4-PAR-PadN3)" class="Default">
+      <node ref="U_DRAM4" pin="N3" pinfunction="PAR" pintype="input"/>
+    </net>
+    <net code="251" name="unconnected-(U_DRAM4-TDQS_c-PadA3)" class="Default">
+      <node ref="U_DRAM4" pin="A3" pinfunction="TDQS_c" pintype="output"/>
+    </net>
+    <net code="252" name="unconnected-(U_DRAM4-TEN-PadG9)" class="Default">
+      <node ref="U_DRAM4" pin="G9" pinfunction="TEN" pintype="input"/>
+    </net>
+    <net code="253" name="unconnected-(U_DRAM4-ZQ-PadB9)" class="Default">
+      <node ref="U_DRAM4" pin="B9" pinfunction="ZQ" pintype="passive"/>
+    </net>
+    <net code="254" name="unconnected-(U_DRAM4-~{ALERT}-PadL9)" class="Default">
+      <node ref="U_DRAM4" pin="L9" pinfunction="~{ALERT}" pintype="open_collector"/>
+    </net>
+    <net code="255" name="unconnected-(U_DRAM5-NC/C0/CKE1-PadG2)" class="Default">
+      <node ref="U_DRAM5" pin="G2" pinfunction="NC/C0/CKE1" pintype="passive"/>
+    </net>
+    <net code="256" name="unconnected-(U_DRAM5-NC/C1/~{CS1}-PadG8)" class="Default">
+      <node ref="U_DRAM5" pin="G8" pinfunction="NC/C1/~{CS1}" pintype="passive"/>
+    </net>
+    <net code="257" name="unconnected-(U_DRAM5-NC/C2/ODT1-PadF2)" class="Default">
+      <node ref="U_DRAM5" pin="F2" pinfunction="NC/C2/ODT1" pintype="passive"/>
+    </net>
+    <net code="258" name="unconnected-(U_DRAM5-PAR-PadN3)" class="Default">
+      <node ref="U_DRAM5" pin="N3" pinfunction="PAR" pintype="input"/>
+    </net>
+    <net code="259" name="unconnected-(U_DRAM5-TDQS_c-PadA3)" class="Default">
+      <node ref="U_DRAM5" pin="A3" pinfunction="TDQS_c" pintype="output"/>
+    </net>
+    <net code="260" name="unconnected-(U_DRAM5-TEN-PadG9)" class="Default">
+      <node ref="U_DRAM5" pin="G9" pinfunction="TEN" pintype="input"/>
+    </net>
+    <net code="261" name="unconnected-(U_DRAM5-ZQ-PadB9)" class="Default">
+      <node ref="U_DRAM5" pin="B9" pinfunction="ZQ" pintype="passive"/>
+    </net>
+    <net code="262" name="unconnected-(U_DRAM5-~{ALERT}-PadL9)" class="Default">
+      <node ref="U_DRAM5" pin="L9" pinfunction="~{ALERT}" pintype="open_collector"/>
+    </net>
+    <net code="263" name="unconnected-(U_DRAM6-NC/C0/CKE1-PadG2)" class="Default">
+      <node ref="U_DRAM6" pin="G2" pinfunction="NC/C0/CKE1" pintype="passive"/>
+    </net>
+    <net code="264" name="unconnected-(U_DRAM6-NC/C1/~{CS1}-PadG8)" class="Default">
+      <node ref="U_DRAM6" pin="G8" pinfunction="NC/C1/~{CS1}" pintype="passive"/>
+    </net>
+    <net code="265" name="unconnected-(U_DRAM6-NC/C2/ODT1-PadF2)" class="Default">
+      <node ref="U_DRAM6" pin="F2" pinfunction="NC/C2/ODT1" pintype="passive"/>
+    </net>
+    <net code="266" name="unconnected-(U_DRAM6-PAR-PadN3)" class="Default">
+      <node ref="U_DRAM6" pin="N3" pinfunction="PAR" pintype="input"/>
+    </net>
+    <net code="267" name="unconnected-(U_DRAM6-TDQS_c-PadA3)" class="Default">
+      <node ref="U_DRAM6" pin="A3" pinfunction="TDQS_c" pintype="output"/>
+    </net>
+    <net code="268" name="unconnected-(U_DRAM6-TEN-PadG9)" class="Default">
+      <node ref="U_DRAM6" pin="G9" pinfunction="TEN" pintype="input"/>
+    </net>
+    <net code="269" name="unconnected-(U_DRAM6-ZQ-PadB9)" class="Default">
+      <node ref="U_DRAM6" pin="B9" pinfunction="ZQ" pintype="passive"/>
+    </net>
+    <net code="270" name="unconnected-(U_DRAM6-~{ALERT}-PadL9)" class="Default">
+      <node ref="U_DRAM6" pin="L9" pinfunction="~{ALERT}" pintype="open_collector"/>
+    </net>
+    <net code="271" name="unconnected-(U_DRAM7-NC/C0/CKE1-PadG2)" class="Default">
+      <node ref="U_DRAM7" pin="G2" pinfunction="NC/C0/CKE1" pintype="passive"/>
+    </net>
+    <net code="272" name="unconnected-(U_DRAM7-NC/C1/~{CS1}-PadG8)" class="Default">
+      <node ref="U_DRAM7" pin="G8" pinfunction="NC/C1/~{CS1}" pintype="passive"/>
+    </net>
+    <net code="273" name="unconnected-(U_DRAM7-NC/C2/ODT1-PadF2)" class="Default">
+      <node ref="U_DRAM7" pin="F2" pinfunction="NC/C2/ODT1" pintype="passive"/>
+    </net>
+    <net code="274" name="unconnected-(U_DRAM7-PAR-PadN3)" class="Default">
+      <node ref="U_DRAM7" pin="N3" pinfunction="PAR" pintype="input"/>
+    </net>
+    <net code="275" name="unconnected-(U_DRAM7-TDQS_c-PadA3)" class="Default">
+      <node ref="U_DRAM7" pin="A3" pinfunction="TDQS_c" pintype="output"/>
+    </net>
+    <net code="276" name="unconnected-(U_DRAM7-TEN-PadG9)" class="Default">
+      <node ref="U_DRAM7" pin="G9" pinfunction="TEN" pintype="input"/>
+    </net>
+    <net code="277" name="unconnected-(U_DRAM7-ZQ-PadB9)" class="Default">
+      <node ref="U_DRAM7" pin="B9" pinfunction="ZQ" pintype="passive"/>
+    </net>
+    <net code="278" name="unconnected-(U_DRAM7-~{ALERT}-PadL9)" class="Default">
+      <node ref="U_DRAM7" pin="L9" pinfunction="~{ALERT}" pintype="open_collector"/>
+    </net>
+  </nets>
+</export>

--- a/design/power/omi_v1_power/omi.kicad_sym
+++ b/design/power/omi_v1_power/omi.kicad_sym
@@ -1,0 +1,5263 @@
+(kicad_symbol_lib
+	(version 20241209)
+	(generator "kicad_symbol_editor")
+	(generator_version "9.0")
+	(symbol "DDR4_UDIMM_288_Edge"
+		(pin_names
+			(offset 1.016)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "J"
+			(at 0 187.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DDR4_UDIMM_288_Edge"
+			(at 0 -190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "DDR4 UDIMM 288-pin edge connector; generated from ddr4_udimm_288_pinmap.csv"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "ki_keywords" "DDR4 UDIMM 288 edge connector DIMM"
+			(at 0 0 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "DDR4_UDIMM_288_Edge_1_1"
+			(rectangle
+				(start -20.32 182.88)
+				(end 20.32 -185.42)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 180.34 0)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 177.8 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 175.26 0)
+				(length 5.08)
+				(name "DQ4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 172.72 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 170.18 0)
+				(length 5.08)
+				(name "DQ0"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 167.64 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 165.1 0)
+				(length 5.08)
+				(name "DM0_n/DBI0_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 162.56 0)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 160.02 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 157.48 0)
+				(length 5.08)
+				(name "DQ6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 154.94 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 152.4 0)
+				(length 5.08)
+				(name "DQ2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 149.86 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 147.32 0)
+				(length 5.08)
+				(name "DQ12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 144.78 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 142.24 0)
+				(length 5.08)
+				(name "DQ8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 139.7 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 137.16 0)
+				(length 5.08)
+				(name "DM1_n/DBI1_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 134.62 0)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 132.08 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 129.54 0)
+				(length 5.08)
+				(name "DQ14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 127 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 124.46 0)
+				(length 5.08)
+				(name "DQ10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 121.92 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 119.38 0)
+				(length 5.08)
+				(name "DQ20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 116.84 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 114.3 0)
+				(length 5.08)
+				(name "DQ16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 111.76 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 109.22 0)
+				(length 5.08)
+				(name "DM2_n/DBI2_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 106.68 0)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 104.14 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 101.6 0)
+				(length 5.08)
+				(name "DQ22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 99.06 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 96.52 0)
+				(length 5.08)
+				(name "DQ18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "34"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 93.98 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "35"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 91.44 0)
+				(length 5.08)
+				(name "DQ28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "36"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 88.9 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "37"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 86.36 0)
+				(length 5.08)
+				(name "DQ24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "38"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 83.82 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "39"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 81.28 0)
+				(length 5.08)
+				(name "DM3_n/DBI3_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "40"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 78.74 0)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "41"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 76.2 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "42"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 73.66 0)
+				(length 5.08)
+				(name "DQ30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "43"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 71.12 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "44"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 68.58 0)
+				(length 5.08)
+				(name "DQ26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "45"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 66.04 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "46"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 63.5 0)
+				(length 5.08)
+				(name "CB4/NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "47"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 60.96 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "48"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 58.42 0)
+				(length 5.08)
+				(name "CB0/NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "49"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 55.88 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "50"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 53.34 0)
+				(length 5.08)
+				(name "DM8_n/DBI8_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "51"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 50.8 0)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "52"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 48.26 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "53"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 45.72 0)
+				(length 5.08)
+				(name "CB6/DBI8_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "54"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 43.18 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "55"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 40.64 0)
+				(length 5.08)
+				(name "CB2/NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "56"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 38.1 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "57"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 35.56 0)
+				(length 5.08)
+				(name "RESET_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "58"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 33.02 0)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "59"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 30.48 0)
+				(length 5.08)
+				(name "CKE0"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "60"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 27.94 0)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "61"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 25.4 0)
+				(length 5.08)
+				(name "ACT_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "62"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 22.86 0)
+				(length 5.08)
+				(name "BG0"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "63"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 20.32 0)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "64"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 17.78 0)
+				(length 5.08)
+				(name "A12/BC_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "65"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 15.24 0)
+				(length 5.08)
+				(name "A9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "66"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 12.7 0)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "67"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 10.16 0)
+				(length 5.08)
+				(name "A8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "68"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 7.62 0)
+				(length 5.08)
+				(name "A6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "69"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 5.08 0)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "70"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 2.54 0)
+				(length 5.08)
+				(name "A3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "71"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 0 0)
+				(length 5.08)
+				(name "A1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "72"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -2.54 0)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "73"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -5.08 0)
+				(length 5.08)
+				(name "CK0_t"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "74"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -7.62 0)
+				(length 5.08)
+				(name "CK0_c"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "75"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -10.16 0)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "76"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -12.7 0)
+				(length 5.08)
+				(name "VTT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "77"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 -15.24 0)
+				(length 5.08)
+				(name "EVENT_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "78"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -17.78 0)
+				(length 5.08)
+				(name "A0"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "79"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -20.32 0)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "80"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -22.86 0)
+				(length 5.08)
+				(name "BA0"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "81"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -25.4 0)
+				(length 5.08)
+				(name "RAS_n/A16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "82"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -27.94 0)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "83"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -30.48 0)
+				(length 5.08)
+				(name "CS0_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "84"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -33.02 0)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "85"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -35.56 0)
+				(length 5.08)
+				(name "CAS_n/A15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "86"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -38.1 0)
+				(length 5.08)
+				(name "ODT0"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "87"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -40.64 0)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "88"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 -43.18 0)
+				(length 5.08)
+				(name "CS1_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "89"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -45.72 0)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "90"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 -48.26 0)
+				(length 5.08)
+				(name "ODT1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "91"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -50.8 0)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "92"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 -53.34 0)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "93"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -55.88 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "94"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -58.42 0)
+				(length 5.08)
+				(name "DQ36"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "95"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -60.96 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "96"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -63.5 0)
+				(length 5.08)
+				(name "DQ32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "97"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -66.04 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "98"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -68.58 0)
+				(length 5.08)
+				(name "DM4_n/DBI4_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "99"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 -71.12 0)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "100"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -73.66 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "101"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -76.2 0)
+				(length 5.08)
+				(name "DQ38"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "102"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -78.74 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "103"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -81.28 0)
+				(length 5.08)
+				(name "DQ34"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "104"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -83.82 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "105"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -86.36 0)
+				(length 5.08)
+				(name "DQ44"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "106"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -88.9 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "107"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -91.44 0)
+				(length 5.08)
+				(name "DQ40"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "108"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -93.98 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "109"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -96.52 0)
+				(length 5.08)
+				(name "DM5_n/DBI5_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "110"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 -99.06 0)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "111"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -101.6 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "112"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -104.14 0)
+				(length 5.08)
+				(name "DQ46"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "113"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -106.68 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "114"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -109.22 0)
+				(length 5.08)
+				(name "DQ42"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "115"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -111.76 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "116"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -114.3 0)
+				(length 5.08)
+				(name "DQ52"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "117"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -116.84 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "118"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -119.38 0)
+				(length 5.08)
+				(name "DQ48"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "119"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -121.92 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "120"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -124.46 0)
+				(length 5.08)
+				(name "DM6_n/DBI6_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "121"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 -127 0)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "122"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -129.54 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "123"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -132.08 0)
+				(length 5.08)
+				(name "DQ54"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "124"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -134.62 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "125"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -137.16 0)
+				(length 5.08)
+				(name "DQ50"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "126"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -139.7 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "127"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -142.24 0)
+				(length 5.08)
+				(name "DQ60"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "128"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -144.78 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "129"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -147.32 0)
+				(length 5.08)
+				(name "DQ56"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "130"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -149.86 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "131"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -152.4 0)
+				(length 5.08)
+				(name "DM7_n/DBI7_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "132"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 -154.94 0)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "133"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -157.48 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "134"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -160.02 0)
+				(length 5.08)
+				(name "DQ62"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "135"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -162.56 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "136"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -165.1 0)
+				(length 5.08)
+				(name "DQ58"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "137"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -167.64 0)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "138"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -170.18 0)
+				(length 5.08)
+				(name "SA0"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "139"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -172.72 0)
+				(length 5.08)
+				(name "SA1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "140"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -175.26 0)
+				(length 5.08)
+				(name "SCL"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "141"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -177.8 0)
+				(length 5.08)
+				(name "VPP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "142"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -25.4 -180.34 0)
+				(length 5.08)
+				(name "VPP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "143"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -25.4 -182.88 0)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "144"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 180.34 180)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "145"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 177.8 180)
+				(length 5.08)
+				(name "VREFCA"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "146"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 175.26 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "147"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 172.72 180)
+				(length 5.08)
+				(name "DQ5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "148"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 170.18 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "149"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 167.64 180)
+				(length 5.08)
+				(name "DQ1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "150"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 165.1 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "151"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 162.56 180)
+				(length 5.08)
+				(name "DQS0_c"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "152"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 160.02 180)
+				(length 5.08)
+				(name "DQS0_t"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "153"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 157.48 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "154"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 154.94 180)
+				(length 5.08)
+				(name "DQ7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "155"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 152.4 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "156"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 149.86 180)
+				(length 5.08)
+				(name "DQ3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "157"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 147.32 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "158"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 144.78 180)
+				(length 5.08)
+				(name "DQ13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "159"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 142.24 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "160"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 139.7 180)
+				(length 5.08)
+				(name "DQ9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "161"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 137.16 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "162"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 134.62 180)
+				(length 5.08)
+				(name "DQS1_c"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "163"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 132.08 180)
+				(length 5.08)
+				(name "DQS1_t"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "164"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 129.54 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "165"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 127 180)
+				(length 5.08)
+				(name "DQ15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "166"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 124.46 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "167"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 121.92 180)
+				(length 5.08)
+				(name "DQ11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "168"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 119.38 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "169"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 116.84 180)
+				(length 5.08)
+				(name "DQ21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "170"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 114.3 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "171"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 111.76 180)
+				(length 5.08)
+				(name "DQ17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "172"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 109.22 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "173"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 106.68 180)
+				(length 5.08)
+				(name "DQS2_c"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "174"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 104.14 180)
+				(length 5.08)
+				(name "DQS2_t"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "175"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 101.6 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "176"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 99.06 180)
+				(length 5.08)
+				(name "DQ23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "177"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 96.52 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "178"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 93.98 180)
+				(length 5.08)
+				(name "DQ19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "179"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 91.44 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "180"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 88.9 180)
+				(length 5.08)
+				(name "DQ29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "181"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 86.36 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "182"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 83.82 180)
+				(length 5.08)
+				(name "DQ25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "183"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 81.28 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "184"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 78.74 180)
+				(length 5.08)
+				(name "DQS3_c"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "185"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 76.2 180)
+				(length 5.08)
+				(name "DQS3_t"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "186"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 73.66 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "187"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 71.12 180)
+				(length 5.08)
+				(name "DQ31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "188"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 68.58 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "189"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 66.04 180)
+				(length 5.08)
+				(name "DQ27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "190"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 63.5 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "191"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 60.96 180)
+				(length 5.08)
+				(name "CB5/NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "192"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 58.42 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "193"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 55.88 180)
+				(length 5.08)
+				(name "CB1/NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "194"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 53.34 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "195"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 50.8 180)
+				(length 5.08)
+				(name "DQS8_c"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "196"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 48.26 180)
+				(length 5.08)
+				(name "DQS8_t"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "197"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 45.72 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "198"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 43.18 180)
+				(length 5.08)
+				(name "CB7/NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "199"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 40.64 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "200"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 38.1 180)
+				(length 5.08)
+				(name "CB3/NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "201"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 35.56 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "202"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 33.02 180)
+				(length 5.08)
+				(name "CKE1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "203"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 30.48 180)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "204"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 27.94 180)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "205"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 25.4 180)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "206"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 22.86 180)
+				(length 5.08)
+				(name "BG1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "207"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 20.32 180)
+				(length 5.08)
+				(name "ALERT_n"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "208"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 17.78 180)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "209"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 15.24 180)
+				(length 5.08)
+				(name "A11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "210"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 12.7 180)
+				(length 5.08)
+				(name "A7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "211"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 10.16 180)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "212"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 7.62 180)
+				(length 5.08)
+				(name "A5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "213"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 5.08 180)
+				(length 5.08)
+				(name "A4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "214"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 2.54 180)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "215"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 0 180)
+				(length 5.08)
+				(name "A2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "216"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -2.54 180)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "217"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 -5.08 180)
+				(length 5.08)
+				(name "CK1_t"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "218"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 -7.62 180)
+				(length 5.08)
+				(name "CK1_c"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "219"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -10.16 180)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "220"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -12.7 180)
+				(length 5.08)
+				(name "VTT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "221"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -15.24 180)
+				(length 5.08)
+				(name "PARITY"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "222"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -17.78 180)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "223"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -20.32 180)
+				(length 5.08)
+				(name "BA1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "224"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -22.86 180)
+				(length 5.08)
+				(name "A10/AP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "225"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -25.4 180)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "226"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 -27.94 180)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "227"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -30.48 180)
+				(length 5.08)
+				(name "WE_n/A14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "228"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -33.02 180)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "229"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 -35.56 180)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "230"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -38.1 180)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "231"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -40.64 180)
+				(length 5.08)
+				(name "A13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "232"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -43.18 180)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "233"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 -45.72 180)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "234"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 -48.26 180)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "235"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -50.8 180)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "236"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 25.4 -53.34 180)
+				(length 5.08)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "237"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -55.88 180)
+				(length 5.08)
+				(name "SA2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "238"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -58.42 180)
+				(length 5.08)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "239"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -60.96 180)
+				(length 5.08)
+				(name "DQ37"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "240"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -63.5 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "241"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -66.04 180)
+				(length 5.08)
+				(name "DQ33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "242"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -68.58 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "243"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -71.12 180)
+				(length 5.08)
+				(name "DQS4_c"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "244"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -73.66 180)
+				(length 5.08)
+				(name "DQS4_t"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "245"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -76.2 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "246"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -78.74 180)
+				(length 5.08)
+				(name "DQ39"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "247"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -81.28 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "248"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -83.82 180)
+				(length 5.08)
+				(name "DQ35"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "249"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -86.36 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "250"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -88.9 180)
+				(length 5.08)
+				(name "DQ45"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "251"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -91.44 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "252"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -93.98 180)
+				(length 5.08)
+				(name "DQ41"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "253"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -96.52 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "254"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -99.06 180)
+				(length 5.08)
+				(name "DQS5_c"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "255"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -101.6 180)
+				(length 5.08)
+				(name "DQS5_t"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "256"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -104.14 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "257"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -106.68 180)
+				(length 5.08)
+				(name "DQ47"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "258"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -109.22 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "259"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -111.76 180)
+				(length 5.08)
+				(name "DQ43"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "260"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -114.3 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "261"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -116.84 180)
+				(length 5.08)
+				(name "DQ53"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "262"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -119.38 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "263"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -121.92 180)
+				(length 5.08)
+				(name "DQ49"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "264"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -124.46 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "265"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -127 180)
+				(length 5.08)
+				(name "DQS6_c"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "266"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -129.54 180)
+				(length 5.08)
+				(name "DQS6_t"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "267"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -132.08 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "268"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -134.62 180)
+				(length 5.08)
+				(name "DQ55"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "269"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -137.16 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "270"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -139.7 180)
+				(length 5.08)
+				(name "DQ51"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "271"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -142.24 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "272"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -144.78 180)
+				(length 5.08)
+				(name "DQ61"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "273"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -147.32 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "274"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -149.86 180)
+				(length 5.08)
+				(name "DQ57"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "275"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -152.4 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "276"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -154.94 180)
+				(length 5.08)
+				(name "DQS7_c"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "277"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -157.48 180)
+				(length 5.08)
+				(name "DQS7_t"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "278"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -160.02 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "279"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -162.56 180)
+				(length 5.08)
+				(name "DQ63"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "280"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -165.1 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "281"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -167.64 180)
+				(length 5.08)
+				(name "DQ59"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "282"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -170.18 180)
+				(length 5.08)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "283"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -172.72 180)
+				(length 5.08)
+				(name "VDDSPD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "284"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -175.26 180)
+				(length 5.08)
+				(name "SDA"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "285"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -177.8 180)
+				(length 5.08)
+				(name "VPP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "286"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -180.34 180)
+				(length 5.08)
+				(name "VPP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "287"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -182.88 180)
+				(length 5.08)
+				(name "VPP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "288"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+)

--- a/design/power/omi_v1_power/sym-lib-table
+++ b/design/power/omi_v1_power/sym-lib-table
@@ -1,0 +1,3 @@
+(sym_lib_table
+  (lib (name "omi")(type "KiCad")(uri "${KIPRJMOD}/omi.kicad_sym")(options "")(descr "OMI v1 generated project symbols (Phase 2: 288-pin DDR4 UDIMM edge connector)"))
+)

--- a/design/power/omi_v1_power/udimm-edge-interface.kicad_sch
+++ b/design/power/omi_v1_power/udimm-edge-interface.kicad_sch
@@ -3,6 +3,11726 @@
 	(generator "eeschema")
 	(generator_version "9.0")
 	(uuid "210817e1-752b-42f4-8fed-a870dd9e41c3")
-	(paper "A4")
-	(lib_symbols)
+	(paper "A2")
+	(lib_symbols
+		(symbol "omi:DDR4_UDIMM_288_Edge"
+				(pin_names
+					(offset 1.016)
+				)
+				(exclude_from_sim no)
+				(in_bom yes)
+				(on_board yes)
+				(property "Reference" "J"
+					(at 0 187.96 0)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(property "Value" "DDR4_UDIMM_288_Edge"
+					(at 0 -190.5 0)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(property "Footprint" ""
+					(at 0 0 0)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+						(hide yes)
+					)
+				)
+				(property "Datasheet" "~"
+					(at 0 0 0)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+						(hide yes)
+					)
+				)
+				(property "Description" "DDR4 UDIMM 288-pin edge connector; generated from ddr4_udimm_288_pinmap.csv"
+					(at 0 0 0)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+						(hide yes)
+					)
+				)
+				(property "ki_keywords" "DDR4 UDIMM 288 edge connector DIMM"
+					(at 0 0 0)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+						(hide yes)
+					)
+				)
+				(symbol "DDR4_UDIMM_288_Edge_1_1"
+					(rectangle
+						(start -20.32 182.88)
+						(end 20.32 -185.42)
+						(stroke
+							(width 0.254)
+							(type default)
+						)
+						(fill
+							(type background)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 180.34 0)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "1"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 177.8 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "2"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 175.26 0)
+						(length 5.08)
+						(name "DQ4"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "3"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 172.72 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "4"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 170.18 0)
+						(length 5.08)
+						(name "DQ0"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "5"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 167.64 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "6"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 165.1 0)
+						(length 5.08)
+						(name "DM0_n/DBI0_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "7"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 162.56 0)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "8"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 160.02 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "9"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 157.48 0)
+						(length 5.08)
+						(name "DQ6"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "10"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 154.94 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "11"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 152.4 0)
+						(length 5.08)
+						(name "DQ2"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "12"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 149.86 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "13"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 147.32 0)
+						(length 5.08)
+						(name "DQ12"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "14"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 144.78 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "15"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 142.24 0)
+						(length 5.08)
+						(name "DQ8"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "16"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 139.7 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "17"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 137.16 0)
+						(length 5.08)
+						(name "DM1_n/DBI1_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "18"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 134.62 0)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "19"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 132.08 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "20"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 129.54 0)
+						(length 5.08)
+						(name "DQ14"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "21"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 127 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "22"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 124.46 0)
+						(length 5.08)
+						(name "DQ10"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "23"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 121.92 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "24"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 119.38 0)
+						(length 5.08)
+						(name "DQ20"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "25"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 116.84 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "26"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 114.3 0)
+						(length 5.08)
+						(name "DQ16"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "27"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 111.76 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "28"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 109.22 0)
+						(length 5.08)
+						(name "DM2_n/DBI2_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "29"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 106.68 0)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "30"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 104.14 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "31"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 101.6 0)
+						(length 5.08)
+						(name "DQ22"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "32"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 99.06 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "33"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 96.52 0)
+						(length 5.08)
+						(name "DQ18"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "34"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 93.98 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "35"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 91.44 0)
+						(length 5.08)
+						(name "DQ28"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "36"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 88.9 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "37"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 86.36 0)
+						(length 5.08)
+						(name "DQ24"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "38"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 83.82 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "39"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 81.28 0)
+						(length 5.08)
+						(name "DM3_n/DBI3_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "40"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 78.74 0)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "41"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 76.2 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "42"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 73.66 0)
+						(length 5.08)
+						(name "DQ30"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "43"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 71.12 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "44"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 68.58 0)
+						(length 5.08)
+						(name "DQ26"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "45"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 66.04 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "46"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 63.5 0)
+						(length 5.08)
+						(name "CB4/NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "47"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 60.96 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "48"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 58.42 0)
+						(length 5.08)
+						(name "CB0/NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "49"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 55.88 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "50"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 53.34 0)
+						(length 5.08)
+						(name "DM8_n/DBI8_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "51"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 50.8 0)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "52"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 48.26 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "53"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 45.72 0)
+						(length 5.08)
+						(name "CB6/DBI8_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "54"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 43.18 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "55"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 40.64 0)
+						(length 5.08)
+						(name "CB2/NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "56"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 38.1 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "57"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 35.56 0)
+						(length 5.08)
+						(name "RESET_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "58"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 33.02 0)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "59"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 30.48 0)
+						(length 5.08)
+						(name "CKE0"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "60"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 27.94 0)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "61"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 25.4 0)
+						(length 5.08)
+						(name "ACT_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "62"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 22.86 0)
+						(length 5.08)
+						(name "BG0"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "63"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 20.32 0)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "64"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 17.78 0)
+						(length 5.08)
+						(name "A12/BC_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "65"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 15.24 0)
+						(length 5.08)
+						(name "A9"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "66"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 12.7 0)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "67"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 10.16 0)
+						(length 5.08)
+						(name "A8"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "68"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 7.62 0)
+						(length 5.08)
+						(name "A6"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "69"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 5.08 0)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "70"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 2.54 0)
+						(length 5.08)
+						(name "A3"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "71"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 0 0)
+						(length 5.08)
+						(name "A1"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "72"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -2.54 0)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "73"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -5.08 0)
+						(length 5.08)
+						(name "CK0_t"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "74"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -7.62 0)
+						(length 5.08)
+						(name "CK0_c"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "75"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -10.16 0)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "76"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -12.7 0)
+						(length 5.08)
+						(name "VTT"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "77"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 -15.24 0)
+						(length 5.08)
+						(name "EVENT_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "78"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -17.78 0)
+						(length 5.08)
+						(name "A0"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "79"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -20.32 0)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "80"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -22.86 0)
+						(length 5.08)
+						(name "BA0"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "81"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -25.4 0)
+						(length 5.08)
+						(name "RAS_n/A16"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "82"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -27.94 0)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "83"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -30.48 0)
+						(length 5.08)
+						(name "CS0_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "84"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -33.02 0)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "85"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -35.56 0)
+						(length 5.08)
+						(name "CAS_n/A15"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "86"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -38.1 0)
+						(length 5.08)
+						(name "ODT0"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "87"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -40.64 0)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "88"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 -43.18 0)
+						(length 5.08)
+						(name "CS1_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "89"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -45.72 0)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "90"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 -48.26 0)
+						(length 5.08)
+						(name "ODT1"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "91"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -50.8 0)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "92"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 -53.34 0)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "93"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -55.88 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "94"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -58.42 0)
+						(length 5.08)
+						(name "DQ36"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "95"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -60.96 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "96"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -63.5 0)
+						(length 5.08)
+						(name "DQ32"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "97"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -66.04 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "98"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -68.58 0)
+						(length 5.08)
+						(name "DM4_n/DBI4_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "99"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 -71.12 0)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "100"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -73.66 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "101"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -76.2 0)
+						(length 5.08)
+						(name "DQ38"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "102"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -78.74 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "103"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -81.28 0)
+						(length 5.08)
+						(name "DQ34"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "104"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -83.82 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "105"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -86.36 0)
+						(length 5.08)
+						(name "DQ44"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "106"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -88.9 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "107"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -91.44 0)
+						(length 5.08)
+						(name "DQ40"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "108"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -93.98 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "109"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -96.52 0)
+						(length 5.08)
+						(name "DM5_n/DBI5_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "110"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 -99.06 0)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "111"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -101.6 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "112"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -104.14 0)
+						(length 5.08)
+						(name "DQ46"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "113"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -106.68 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "114"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -109.22 0)
+						(length 5.08)
+						(name "DQ42"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "115"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -111.76 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "116"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -114.3 0)
+						(length 5.08)
+						(name "DQ52"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "117"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -116.84 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "118"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -119.38 0)
+						(length 5.08)
+						(name "DQ48"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "119"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -121.92 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "120"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -124.46 0)
+						(length 5.08)
+						(name "DM6_n/DBI6_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "121"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 -127 0)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "122"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -129.54 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "123"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -132.08 0)
+						(length 5.08)
+						(name "DQ54"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "124"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -134.62 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "125"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -137.16 0)
+						(length 5.08)
+						(name "DQ50"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "126"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -139.7 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "127"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -142.24 0)
+						(length 5.08)
+						(name "DQ60"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "128"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -144.78 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "129"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -147.32 0)
+						(length 5.08)
+						(name "DQ56"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "130"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -149.86 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "131"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -152.4 0)
+						(length 5.08)
+						(name "DM7_n/DBI7_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "132"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 -154.94 0)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "133"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -157.48 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "134"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -160.02 0)
+						(length 5.08)
+						(name "DQ62"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "135"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -162.56 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "136"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -165.1 0)
+						(length 5.08)
+						(name "DQ58"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "137"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -167.64 0)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "138"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -170.18 0)
+						(length 5.08)
+						(name "SA0"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "139"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -172.72 0)
+						(length 5.08)
+						(name "SA1"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "140"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -175.26 0)
+						(length 5.08)
+						(name "SCL"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "141"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -177.8 0)
+						(length 5.08)
+						(name "VPP"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "142"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at -25.4 -180.34 0)
+						(length 5.08)
+						(name "VPP"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "143"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at -25.4 -182.88 0)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "144"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 180.34 180)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "145"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 177.8 180)
+						(length 5.08)
+						(name "VREFCA"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "146"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 175.26 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "147"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 172.72 180)
+						(length 5.08)
+						(name "DQ5"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "148"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 170.18 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "149"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 167.64 180)
+						(length 5.08)
+						(name "DQ1"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "150"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 165.1 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "151"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 162.56 180)
+						(length 5.08)
+						(name "DQS0_c"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "152"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 160.02 180)
+						(length 5.08)
+						(name "DQS0_t"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "153"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 157.48 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "154"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 154.94 180)
+						(length 5.08)
+						(name "DQ7"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "155"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 152.4 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "156"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 149.86 180)
+						(length 5.08)
+						(name "DQ3"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "157"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 147.32 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "158"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 144.78 180)
+						(length 5.08)
+						(name "DQ13"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "159"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 142.24 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "160"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 139.7 180)
+						(length 5.08)
+						(name "DQ9"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "161"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 137.16 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "162"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 134.62 180)
+						(length 5.08)
+						(name "DQS1_c"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "163"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 132.08 180)
+						(length 5.08)
+						(name "DQS1_t"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "164"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 129.54 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "165"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 127 180)
+						(length 5.08)
+						(name "DQ15"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "166"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 124.46 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "167"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 121.92 180)
+						(length 5.08)
+						(name "DQ11"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "168"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 119.38 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "169"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 116.84 180)
+						(length 5.08)
+						(name "DQ21"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "170"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 114.3 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "171"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 111.76 180)
+						(length 5.08)
+						(name "DQ17"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "172"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 109.22 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "173"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 106.68 180)
+						(length 5.08)
+						(name "DQS2_c"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "174"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 104.14 180)
+						(length 5.08)
+						(name "DQS2_t"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "175"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 101.6 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "176"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 99.06 180)
+						(length 5.08)
+						(name "DQ23"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "177"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 96.52 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "178"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 93.98 180)
+						(length 5.08)
+						(name "DQ19"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "179"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 91.44 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "180"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 88.9 180)
+						(length 5.08)
+						(name "DQ29"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "181"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 86.36 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "182"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 83.82 180)
+						(length 5.08)
+						(name "DQ25"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "183"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 81.28 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "184"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 78.74 180)
+						(length 5.08)
+						(name "DQS3_c"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "185"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 76.2 180)
+						(length 5.08)
+						(name "DQS3_t"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "186"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 73.66 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "187"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 71.12 180)
+						(length 5.08)
+						(name "DQ31"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "188"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 68.58 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "189"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 66.04 180)
+						(length 5.08)
+						(name "DQ27"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "190"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 63.5 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "191"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 60.96 180)
+						(length 5.08)
+						(name "CB5/NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "192"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 58.42 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "193"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 55.88 180)
+						(length 5.08)
+						(name "CB1/NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "194"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 53.34 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "195"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 50.8 180)
+						(length 5.08)
+						(name "DQS8_c"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "196"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 48.26 180)
+						(length 5.08)
+						(name "DQS8_t"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "197"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 45.72 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "198"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 43.18 180)
+						(length 5.08)
+						(name "CB7/NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "199"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 40.64 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "200"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 38.1 180)
+						(length 5.08)
+						(name "CB3/NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "201"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 35.56 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "202"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 33.02 180)
+						(length 5.08)
+						(name "CKE1"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "203"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 30.48 180)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "204"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 27.94 180)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "205"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 25.4 180)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "206"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 22.86 180)
+						(length 5.08)
+						(name "BG1"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "207"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 20.32 180)
+						(length 5.08)
+						(name "ALERT_n"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "208"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 17.78 180)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "209"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 15.24 180)
+						(length 5.08)
+						(name "A11"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "210"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 12.7 180)
+						(length 5.08)
+						(name "A7"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "211"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 10.16 180)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "212"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 7.62 180)
+						(length 5.08)
+						(name "A5"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "213"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 5.08 180)
+						(length 5.08)
+						(name "A4"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "214"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 2.54 180)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "215"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 0 180)
+						(length 5.08)
+						(name "A2"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "216"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -2.54 180)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "217"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 -5.08 180)
+						(length 5.08)
+						(name "CK1_t"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "218"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 -7.62 180)
+						(length 5.08)
+						(name "CK1_c"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "219"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -10.16 180)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "220"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -12.7 180)
+						(length 5.08)
+						(name "VTT"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "221"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -15.24 180)
+						(length 5.08)
+						(name "PARITY"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "222"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -17.78 180)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "223"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -20.32 180)
+						(length 5.08)
+						(name "BA1"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "224"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -22.86 180)
+						(length 5.08)
+						(name "A10/AP"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "225"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -25.4 180)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "226"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 -27.94 180)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "227"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -30.48 180)
+						(length 5.08)
+						(name "WE_n/A14"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "228"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -33.02 180)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "229"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 -35.56 180)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "230"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -38.1 180)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "231"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -40.64 180)
+						(length 5.08)
+						(name "A13"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "232"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -43.18 180)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "233"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 -45.72 180)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "234"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 -48.26 180)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "235"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -50.8 180)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "236"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin no_connect line
+						(at 25.4 -53.34 180)
+						(length 5.08)
+						(name "NC"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "237"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -55.88 180)
+						(length 5.08)
+						(name "SA2"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "238"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -58.42 180)
+						(length 5.08)
+						(name "VDD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "239"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -60.96 180)
+						(length 5.08)
+						(name "DQ37"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "240"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -63.5 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "241"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -66.04 180)
+						(length 5.08)
+						(name "DQ33"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "242"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -68.58 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "243"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -71.12 180)
+						(length 5.08)
+						(name "DQS4_c"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "244"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -73.66 180)
+						(length 5.08)
+						(name "DQS4_t"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "245"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -76.2 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "246"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -78.74 180)
+						(length 5.08)
+						(name "DQ39"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "247"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -81.28 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "248"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -83.82 180)
+						(length 5.08)
+						(name "DQ35"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "249"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -86.36 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "250"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -88.9 180)
+						(length 5.08)
+						(name "DQ45"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "251"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -91.44 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "252"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -93.98 180)
+						(length 5.08)
+						(name "DQ41"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "253"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -96.52 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "254"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -99.06 180)
+						(length 5.08)
+						(name "DQS5_c"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "255"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -101.6 180)
+						(length 5.08)
+						(name "DQS5_t"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "256"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -104.14 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "257"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -106.68 180)
+						(length 5.08)
+						(name "DQ47"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "258"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -109.22 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "259"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -111.76 180)
+						(length 5.08)
+						(name "DQ43"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "260"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -114.3 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "261"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -116.84 180)
+						(length 5.08)
+						(name "DQ53"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "262"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -119.38 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "263"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -121.92 180)
+						(length 5.08)
+						(name "DQ49"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "264"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -124.46 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "265"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -127 180)
+						(length 5.08)
+						(name "DQS6_c"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "266"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -129.54 180)
+						(length 5.08)
+						(name "DQS6_t"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "267"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -132.08 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "268"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -134.62 180)
+						(length 5.08)
+						(name "DQ55"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "269"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -137.16 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "270"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -139.7 180)
+						(length 5.08)
+						(name "DQ51"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "271"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -142.24 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "272"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -144.78 180)
+						(length 5.08)
+						(name "DQ61"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "273"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -147.32 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "274"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -149.86 180)
+						(length 5.08)
+						(name "DQ57"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "275"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -152.4 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "276"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -154.94 180)
+						(length 5.08)
+						(name "DQS7_c"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "277"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -157.48 180)
+						(length 5.08)
+						(name "DQS7_t"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "278"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -160.02 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "279"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -162.56 180)
+						(length 5.08)
+						(name "DQ63"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "280"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -165.1 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "281"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -167.64 180)
+						(length 5.08)
+						(name "DQ59"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "282"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -170.18 180)
+						(length 5.08)
+						(name "VSS"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "283"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -172.72 180)
+						(length 5.08)
+						(name "VDDSPD"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "284"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -175.26 180)
+						(length 5.08)
+						(name "SDA"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "285"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -177.8 180)
+						(length 5.08)
+						(name "VPP"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "286"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -180.34 180)
+						(length 5.08)
+						(name "VPP"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "287"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+					(pin passive line
+						(at 25.4 -182.88 180)
+						(length 5.08)
+						(name "VPP"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+						(number "288"
+							(effects
+								(font
+									(size 1.27 1.27)
+								)
+							)
+						)
+					)
+				)
+				(embedded_fonts no)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 12.7 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "eefc043c-9062-540c-af7c-f72cf522331f")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 12.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D0_DQ4"
+		(shape input)
+		(at 127 15.24 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "5a10dd20-8cd4-576d-ad3f-1c43027789da")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 15.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 17.78 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1461e209-96d9-5630-90b8-dbb8b1240b1d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 17.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D0_DQ0"
+		(shape input)
+		(at 127 20.32 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "45929a0f-76e0-5a4e-939b-296cad55af9e")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 22.86 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0dbf82f6-4b00-59d9-a355-a50dff946255")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 22.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D0_DM_DBI_n"
+		(shape input)
+		(at 127 25.4 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1d75dafd-e63f-5d23-b712-d28929d1a732")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 30.48 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8710cdc3-618a-5b03-a0d7-bc05619e5899")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 30.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D0_DQ6"
+		(shape input)
+		(at 127 33.02 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "b76c3bbf-3a34-5150-bc17-9d1922f16b1d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 35.56 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "48dd2777-a9e5-5f85-8c48-652c966b41cf")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D0_DQ2"
+		(shape input)
+		(at 127 38.1 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "9d354546-f1eb-5bba-ad20-41eeb4c58779")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 38.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 40.64 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "af83ee66-7670-5cc5-bc39-2533f695a01a")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D1_DQ4"
+		(shape input)
+		(at 127 43.18 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8510f2bd-53cc-560c-bb0f-af78128b4a3f")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 45.72 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "06199eb8-d21f-5f49-93e2-c8e4ba14ae0f")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D1_DQ0"
+		(shape input)
+		(at 127 48.26 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "09cb1e68-8540-57c2-8b0e-1e60b9afc3ca")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 50.8 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1a109ef1-7629-5bad-8062-2f516847c473")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D1_DM_DBI_n"
+		(shape input)
+		(at 127 53.34 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "981068b1-da81-515e-a833-18d3eb12a2f6")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 58.42 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "827e2851-102c-517e-8f15-3233499a215b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D1_DQ6"
+		(shape input)
+		(at 127 60.96 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "00b3489b-137d-581f-9782-8ff1de99e0a5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 63.5 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "9cfdfd10-e0d1-554d-8bec-4a9169510131")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 63.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D1_DQ2"
+		(shape input)
+		(at 127 66.04 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "218bd110-32f8-5c0a-8c18-97c761ce2ada")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 66.04 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 68.58 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a48efbbc-8721-5828-ac12-ab0b4a5e3ae1")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D2_DQ4"
+		(shape input)
+		(at 127 71.12 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "845e4b23-f8ff-567c-bbf6-19e4cd94e48b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 71.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 73.66 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c27cadeb-01e3-5015-914f-023bf698a9a7")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 73.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D2_DQ0"
+		(shape input)
+		(at 127 76.2 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "779bbf8d-2803-561c-8a28-4655b06e76c4")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 78.74 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "711ac604-57e1-5dae-92bd-e1a26a442239")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 78.74 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D2_DM_DBI_n"
+		(shape input)
+		(at 127 81.28 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ebabf311-6052-556d-92ac-6acb16ddc0f6")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 86.36 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c3076209-55ec-5d02-8bdf-b3211e6fd70d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 86.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D2_DQ6"
+		(shape input)
+		(at 127 88.9 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "cf11fff4-8078-54bf-a1b7-2ec81d96a573")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 91.44 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1695cdf6-cba4-5a6c-8f76-de9625b9f9ae")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D2_DQ2"
+		(shape input)
+		(at 127 93.98 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "9c3da13a-53b0-5e44-826f-05c5c004d151")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 96.52 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a3f95e07-4388-5d05-83f4-221996360241")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D3_DQ4"
+		(shape input)
+		(at 127 99.06 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ce302a4a-e720-557a-8e50-4ffa2d81fe7e")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 101.6 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4e918d92-72c3-54f3-876d-a65d4555c260")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D3_DQ0"
+		(shape input)
+		(at 127 104.14 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4184f75e-b7dd-592b-a086-a4c00321b0ae")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 104.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 106.68 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4765f5ca-4518-50d6-bee5-7519d4b6eb7b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D3_DM_DBI_n"
+		(shape input)
+		(at 127 109.22 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "6b3c6dcd-79a6-51a2-9e7c-235ed8fa1b50")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 114.3 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c637a47b-1e3b-5e31-b7cb-15eeab84b2ac")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 114.3 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D3_DQ6"
+		(shape input)
+		(at 127 116.84 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0c1371a2-6b7d-517e-96f2-30d42306dc0e")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 119.38 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "cf5552d2-0bed-5020-8818-11745dcef45d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 119.38 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D3_DQ2"
+		(shape input)
+		(at 127 121.92 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "fd99710d-f11f-54d6-ab84-2d37ae2b5fdd")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 124.46 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a430bec9-86d7-5489-a4e2-d7d0a0299982")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 129.54 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c2aebdab-41e6-5115-b864-0bff37263fcf")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 134.62 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "7e672ec7-aff5-5883-b246-ac89542c04dc")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 134.62 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 142.24 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f79d8b14-5c8c-5b94-b453-2a57744e5954")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 147.32 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "33bbab32-5f90-51bc-be6e-e342d1a42d14")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 147.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 152.4 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d5f236c3-f088-58f2-aa1c-80055b80b38e")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "RESET_n"
+		(shape input)
+		(at 127 154.94 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e1542482-3c9b-5f9f-82bd-d4fa7dfd940e")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 154.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 127 157.48 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "74be32be-d7fe-5e95-b9d1-a001d469de9e")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "CKE0"
+		(shape input)
+		(at 127 160.02 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "9075597a-0c8d-5d6d-889e-0568d69d52f1")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 160.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 127 162.56 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0ade3dca-ed71-5b04-941e-c2717eece550")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "ACT_n"
+		(shape input)
+		(at 127 165.1 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "369b873f-3694-53ca-9bd6-5d164536599b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 165.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "BG0"
+		(shape input)
+		(at 127 167.64 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a37aa035-48a2-55ad-9c81-223f56423567")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 167.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 127 170.18 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "417b88df-0146-56e5-b039-a6664aa2dfd6")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A12"
+		(shape input)
+		(at 127 172.72 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "3b35f67f-9d9d-545e-8848-7ba425902873")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 172.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A9"
+		(shape input)
+		(at 127 175.26 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "b2e79d27-f76e-552e-a18b-c571a423eb6f")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 175.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 127 177.8 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1d3a43f7-4f7d-5d74-8f77-c8bb78b2ef98")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A8"
+		(shape input)
+		(at 127 180.34 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "571ed9fd-3cd5-51ef-a398-1716325870da")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A6"
+		(shape input)
+		(at 127 182.88 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "571828b2-c222-5acb-8e55-d27b50234e39")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 127 185.42 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "923e9fa4-460a-57a8-b81b-7bd8d6ba190f")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A3"
+		(shape input)
+		(at 127 187.96 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "90696538-c2a3-5564-a005-7cd123f97b69")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 187.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A1"
+		(shape input)
+		(at 127 190.5 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "db429b32-0db9-516f-98fc-03561950cd09")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 127 193.04 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "63f72d78-6645-5885-af8e-a62597f0d93d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 193.04 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "CK_t"
+		(shape input)
+		(at 127 195.58 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "109fccb0-0a9e-5234-887f-c0a6c90356b7")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 195.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "CK_c"
+		(shape input)
+		(at 127 198.12 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "5a57a156-b98e-52ef-8a20-f1ed4ebedaa9")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 127 200.66 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "bcc7379e-429c-57f6-8c40-2cf0e1581428")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 200.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VTT"
+		(shape input)
+		(at 127 203.2 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e0143036-ced8-57aa-984a-f760d6cb92eb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A0"
+		(shape input)
+		(at 127 208.28 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4bc8c05f-cda7-5e40-a988-4d76416f733d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 208.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 127 210.82 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "cda6d81b-6891-5c14-8130-7d78ddd69ed5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "BA0"
+		(shape input)
+		(at 127 213.36 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ba3edbde-c807-52be-aa87-eb1af770315e")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 213.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A16"
+		(shape input)
+		(at 127 215.9 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "bfed3482-4e7b-53f4-8add-8245bd919e77")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 215.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 127 218.44 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "5f5619dc-580e-5876-a207-c7c78b4bb8ba")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "CS0_n"
+		(shape input)
+		(at 127 220.98 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c10518b6-6059-5d72-8e92-357937f1b062")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 220.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 127 223.52 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "9b0097f8-ed9f-54ad-bbaf-4fee51b19876")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A15"
+		(shape input)
+		(at 127 226.06 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d3f8bcb6-72ba-5afa-bc89-562a27bb0890")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 226.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "ODT0"
+		(shape input)
+		(at 127 228.6 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "95feb0f4-3419-544d-9b76-30e46c2e5da1")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 228.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 127 231.14 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8ab2e010-1143-56bb-b9fe-b62ca568e9fe")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 231.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 127 236.22 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "28c8d3a0-dcce-5d41-a851-da04fefac28f")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 236.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 127 241.3 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4acabb4b-2414-536e-9ff2-be6b73e33811")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 241.3 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 246.38 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "9d8b4479-7ce5-5826-a87e-3e31ea35fe22")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 246.38 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D4_DQ4"
+		(shape input)
+		(at 127 248.92 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "3ebdca9a-3c9d-5e90-af20-e5d4daefb381")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 248.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 251.46 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8ba768c1-8ee6-5508-add2-f1848844c9e6")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 251.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D4_DQ0"
+		(shape input)
+		(at 127 254 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "6d8deeca-b447-5a68-98c8-95957ed29180")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 254 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 256.54 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "6c6692a8-361a-50d5-ac03-5fa497dba67a")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 256.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D4_DM_DBI_n"
+		(shape input)
+		(at 127 259.08 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0b2ee282-7553-5ec4-888e-dad63354bf75")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 259.08 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 264.16 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "88a9b562-b6d8-5fe3-8b0e-97f66b9696ba")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 264.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D4_DQ6"
+		(shape input)
+		(at 127 266.7 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "9df721ec-8f5b-540a-80d7-58cf0018a814")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 266.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 269.24 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "2069c867-3abc-5c7d-91f2-c3a61c3b591b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 269.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D4_DQ2"
+		(shape input)
+		(at 127 271.78 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "a99ff438-b30d-5d90-b61c-dcfeafccb62f")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 271.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 274.32 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "95d469c5-821d-5f3c-bc39-d9da9ad9d317")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 274.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D5_DQ4"
+		(shape input)
+		(at 127 276.86 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "fa0ec6bb-d406-5831-af4b-23cb87b75183")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 276.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 279.4 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "267df387-1ee5-5849-bf01-f1216b785dd0")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 279.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D5_DQ0"
+		(shape input)
+		(at 127 281.94 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "087f1da0-75da-5f76-9fc5-652de4ce0a4b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 281.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 284.48 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "683adaf8-7e3c-52dc-8e13-4dce882195cd")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 284.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D5_DM_DBI_n"
+		(shape input)
+		(at 127 287.02 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c83f8a48-3987-5142-89ad-d70cebde5d1e")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 287.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 292.1 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "c6a90365-5752-55cd-aa27-e5a70eb47d90")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 292.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D5_DQ6"
+		(shape input)
+		(at 127 294.64 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "5b4db788-be1e-5c14-8026-cf38faa2233c")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 294.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 297.18 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "42ca2b9b-e46d-5d9d-ae68-da934dbeb315")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 297.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D5_DQ2"
+		(shape input)
+		(at 127 299.72 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "7df0558f-04ae-5c99-a457-bedbbd9ee8b9")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 299.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 302.26 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "b9358791-8981-597b-b53c-e819c1af0cb3")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 302.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D6_DQ4"
+		(shape input)
+		(at 127 304.8 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d47ae9c2-53f0-5c4e-8783-48e92e7a7423")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 304.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 307.34 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "bd124838-2895-5939-afa1-a530995550b7")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 307.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D6_DQ0"
+		(shape input)
+		(at 127 309.88 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "deda6b1a-ca28-50cd-bd1c-7ac2076604ae")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 309.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 312.42 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "7b459d98-b2d5-5d60-80de-fa58270adf8c")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 312.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D6_DM_DBI_n"
+		(shape input)
+		(at 127 314.96 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f248a036-8777-5009-a8a9-1869eeffcca5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 314.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 320.04 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e15b7762-d067-50c6-b534-dc765ca7cb65")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 320.04 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D6_DQ6"
+		(shape input)
+		(at 127 322.58 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4963cb63-6b29-5e54-8ac2-1662cf2083de")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 322.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 325.12 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "46f93aa2-df72-504d-a093-8558d6465f1c")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 325.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D6_DQ2"
+		(shape input)
+		(at 127 327.66 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f68f19ad-0f6f-5550-8efc-22a32099081f")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 327.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 330.2 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4c0d5ef7-a3c1-5011-b54f-6d200d2419a8")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 330.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D7_DQ4"
+		(shape input)
+		(at 127 332.74 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ce5168aa-581c-58a4-9b02-11e66a5246d1")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 332.74 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 335.28 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "752212df-21db-5cd0-95a5-7e926d6929e0")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 335.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D7_DQ0"
+		(shape input)
+		(at 127 337.82 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "79114cb6-3128-5b83-a155-af429122e7fc")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 337.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 340.36 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "3864efd3-b6a1-5aea-8bc5-061e49b36d01")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 340.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D7_DM_DBI_n"
+		(shape input)
+		(at 127 342.9 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "22967efd-ea9d-5d4f-b05a-cae96ba2e204")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 342.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 347.98 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "3accfbef-9635-5f1e-ad48-24789cc73d27")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 347.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D7_DQ6"
+		(shape input)
+		(at 127 350.52 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "96649d1a-8107-542c-aede-5a7fe2bed7d4")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 350.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 353.06 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "2bfdfb79-da1d-5162-8dc7-26263382b7b5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 353.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D7_DQ2"
+		(shape input)
+		(at 127 355.6 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1ea5e548-2f93-5307-8bff-e6110468148b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 355.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 127 358.14 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0534877d-5144-562c-80d1-821f10c96b34")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 358.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "SA0"
+		(shape input)
+		(at 127 360.68 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "873373b8-fb32-54ae-8000-23e984532811")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 360.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "SA1"
+		(shape input)
+		(at 127 363.22 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "41e3a0ea-32a4-5b55-b44c-a7db681361a0")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 363.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "SPD_SCL"
+		(shape input)
+		(at 127 365.76 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "6488d048-9cd6-5e03-9d65-e2c8155525e5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 365.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VPP"
+		(shape input)
+		(at 127 368.3 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "65888f0c-fafb-5176-afd2-ed5664db10bc")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 368.3 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VPP"
+		(shape input)
+		(at 127 370.84 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "ec8ce11c-d08f-5f25-ab51-c2bdb8b0a6d4")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 370.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VREF"
+		(shape input)
+		(at 177.8 12.7 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a3658d62-6e5b-52fb-aa3b-d442e140a44e")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 12.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 15.24 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "efe19f7c-18f6-5f7e-86a5-63fc9dfe373b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 15.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D0_DQ5"
+		(shape input)
+		(at 177.8 17.78 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ea7b061e-c58c-5b5d-b5c8-0effae6426f0")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 17.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 20.32 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "bd04b7a3-fbce-5e2b-afb9-f9ca3349c233")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D0_DQ1"
+		(shape input)
+		(at 177.8 22.86 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e3a2e936-dd21-5a52-be6b-f96a578c67de")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 22.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 25.4 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ade7a056-6c05-5495-8bc9-ab4939b4cbd7")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D0_DQS_c"
+		(shape input)
+		(at 177.8 27.94 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "04903e2f-42f4-5e64-a788-d5c894d2ccb3")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 27.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D0_DQS_t"
+		(shape input)
+		(at 177.8 30.48 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0b043a95-dfac-520e-955e-25263ee0c95f")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 30.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 33.02 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "802578ae-67a5-54db-80db-49c4f4e760e9")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 33.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D0_DQ7"
+		(shape input)
+		(at 177.8 35.56 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "849ce5ab-c115-507c-b3e1-1fd564511b38")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 38.1 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "065c43ad-5148-5170-9f80-e1e17afda7e4")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 38.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D0_DQ3"
+		(shape input)
+		(at 177.8 40.64 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "98b67093-2ec8-587a-896c-9f25199f5a6b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 43.18 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "fc3b07b2-c3e2-5b13-8e84-e7feeae3a82f")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D1_DQ5"
+		(shape input)
+		(at 177.8 45.72 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "512329a8-80d3-5e73-b6a9-5289d60ef697")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 48.26 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "3ee43826-a734-5905-87b6-dd0469915c79")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D1_DQ1"
+		(shape input)
+		(at 177.8 50.8 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0fcea094-122e-59e0-b5ea-3526099d3662")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 53.34 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "eda09e40-8776-5158-9e98-594dee7c2892")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D1_DQS_c"
+		(shape input)
+		(at 177.8 55.88 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "41d2637d-9a2a-541a-a48f-b67e48ced7d3")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D1_DQS_t"
+		(shape input)
+		(at 177.8 58.42 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "26902360-1e0b-5245-ab55-a02f16086f32")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 58.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 60.96 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e191348c-b5d2-5cb5-b9bd-9a579a618da0")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D1_DQ7"
+		(shape input)
+		(at 177.8 63.5 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9620f208-e283-5c7d-818c-c1d592f69db5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 63.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 66.04 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1f1e62d2-44f3-58c7-95dc-95d5a9855197")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 66.04 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D1_DQ3"
+		(shape input)
+		(at 177.8 68.58 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "686f514f-bbf7-59d9-8d0a-e3a4b8ba7257")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 71.12 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f7aeff78-7190-5afb-8b67-ab64188f5753")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 71.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D2_DQ5"
+		(shape input)
+		(at 177.8 73.66 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4405a8ce-20c8-5a3c-b67c-e7b583ac72fd")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 73.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 76.2 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "db1cbb72-a309-5dc0-bbf8-081a8cba3bfc")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D2_DQ1"
+		(shape input)
+		(at 177.8 78.74 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e77447c5-d47c-51e3-b2fd-27f6bb52084a")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 78.74 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 81.28 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "654c4c89-1412-5d93-b74f-8f6ab3d2f482")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D2_DQS_c"
+		(shape input)
+		(at 177.8 83.82 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "78239bc3-aba1-50fa-bf7d-d2f9258172ec")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D2_DQS_t"
+		(shape input)
+		(at 177.8 86.36 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "7edf7e1f-9593-550b-83a8-5ef3d384a180")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 86.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 88.9 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "89a9189d-1fef-5f92-b28f-ef9551c52d05")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D2_DQ7"
+		(shape input)
+		(at 177.8 91.44 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "91052739-dbbe-5d8f-a39e-c1c61bd68ac9")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 93.98 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a9cf0027-eee9-5e2d-9c0e-effd6e47411b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D2_DQ3"
+		(shape input)
+		(at 177.8 96.52 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a00e8348-6d71-5737-b9a5-8243ad4fb034")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 99.06 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "7389f97f-5676-5694-9cfb-b0000038f9a2")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D3_DQ5"
+		(shape input)
+		(at 177.8 101.6 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "fc1289f2-9b99-556e-8c4c-624ac914b6ae")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 104.14 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "115fe465-a7b9-51e4-a6a4-4013f4167eab")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 104.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D3_DQ1"
+		(shape input)
+		(at 177.8 106.68 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1eb6ce96-57c8-5945-bcdb-4769331052ce")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 109.22 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5d7e080f-818a-5c3d-b3d8-539d36416c62")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D3_DQS_c"
+		(shape input)
+		(at 177.8 111.76 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2ad2fc32-ea40-59a5-87c2-53470970064f")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 111.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D3_DQS_t"
+		(shape input)
+		(at 177.8 114.3 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e9453109-fd3b-51ab-8e52-c90889f10546")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 114.3 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 116.84 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8dc0834b-86a5-5ec7-8e7a-9f33447045ba")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D3_DQ7"
+		(shape input)
+		(at 177.8 119.38 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "626d3f68-2f74-5809-8040-51791cec38b7")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 119.38 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 121.92 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9790d5bd-3eff-5b00-b43a-3a2722c1d187")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D3_DQ3"
+		(shape input)
+		(at 177.8 124.46 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "881eb05c-1d9a-5d61-b719-b93197e7dc9b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 127 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ae310fd1-faba-5b8e-9d87-1f0227239872")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 127 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 132.08 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a8b8ba42-fa90-5667-ace8-e74a3959328b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 132.08 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 137.16 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "fb15cfde-873f-51b6-99a1-5a34f24bef39")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 144.78 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "be62831c-b34a-5edc-9fc9-ffe837754102")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 144.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 149.86 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "27ea6d07-0497-5977-9515-08ee433e12ae")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 154.94 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "3615c756-0eaa-5b3d-8f57-2bc12e961595")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 154.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 177.8 160.02 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "34fa68da-4826-5ad8-814d-eec2825fbb10")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 160.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 177.8 165.1 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8e166f95-6232-5f06-abf1-654e45261e5b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 165.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "BG1"
+		(shape input)
+		(at 177.8 167.64 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "bf521b84-de1a-55cb-a9d5-8f28e4c85494")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 167.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "ALERT_n"
+		(shape input)
+		(at 177.8 170.18 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "65234f7a-7cbe-599d-ab20-df79cc844670")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 177.8 172.72 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "56fd283b-4856-5ae8-8329-bd6cae051bf4")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 172.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A11"
+		(shape input)
+		(at 177.8 175.26 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "99d976e9-4ac2-5ef2-92b8-dc8e007bd847")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 175.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A7"
+		(shape input)
+		(at 177.8 177.8 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "429b9988-9f16-5149-9699-3e5a5c092725")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 177.8 180.34 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "cb0594a2-af4c-5258-9078-b90c58338e18")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A5"
+		(shape input)
+		(at 177.8 182.88 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "cd1fcd73-d478-544b-9c4d-237fffb9a192")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A4"
+		(shape input)
+		(at 177.8 185.42 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "15c8d9d2-e685-5776-b2df-e3a4e65047ce")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 177.8 187.96 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5137e9e2-1705-5818-a37f-487e8aeeb6ac")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 187.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A2"
+		(shape input)
+		(at 177.8 190.5 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4ef7ab15-6ee9-50d0-8578-ff8b72e9da83")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 177.8 193.04 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ea868c90-575b-5a1f-8eaf-b5b8ea84e8bf")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 193.04 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 177.8 200.66 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f3e99705-160f-5061-a449-2cff1fbe7cc6")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 200.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VTT"
+		(shape input)
+		(at 177.8 203.2 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "89bc7af2-660d-5031-9c6b-71578db70816")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "PARITY"
+		(shape input)
+		(at 177.8 205.74 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2f40d281-52ac-5cd7-81da-966a6c5c5028")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 205.74 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 177.8 208.28 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "26254183-3635-5e79-a86d-fd995eabe312")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 208.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "BA1"
+		(shape input)
+		(at 177.8 210.82 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "313da110-3927-507d-aecd-14b478baa6f2")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A10"
+		(shape input)
+		(at 177.8 213.36 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2ab2f053-a3a1-52e4-a05b-fb98b375b004")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 213.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 177.8 215.9 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "392eafa1-146c-5c31-ab53-b99aa499a8cd")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 215.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A14"
+		(shape input)
+		(at 177.8 220.98 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f926fd2b-5c1f-54da-9686-d96f3691a333")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 220.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 177.8 223.52 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ad717d50-dbf6-5dd1-95d0-53560f953b26")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 177.8 228.6 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d68b72aa-e933-5bf3-9165-c5160f5d3398")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 228.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "A13"
+		(shape input)
+		(at 177.8 231.14 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "bde40426-9d2e-5f0e-a089-13cbd7081149")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 231.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 177.8 233.68 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1752f14f-3d09-5342-b365-6146de529926")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 233.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 177.8 241.3 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f29823b2-12fb-5400-a249-f8fb2f522695")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 241.3 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "SA2"
+		(shape input)
+		(at 177.8 246.38 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0d62db30-1759-568e-ad14-edfe4b1ac39d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 246.38 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDD"
+		(shape input)
+		(at 177.8 248.92 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "116528a3-2e82-5206-b02d-29f62800a6d6")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 248.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D4_DQ5"
+		(shape input)
+		(at 177.8 251.46 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "bd03925d-1090-5463-8e35-04716d9629d5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 251.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 254 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "278fa2cf-f672-5c1a-964e-e0f21ca98afd")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 254 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D4_DQ1"
+		(shape input)
+		(at 177.8 256.54 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8b403e78-2586-5c31-bde6-49c88d7b3bfe")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 256.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 259.08 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5deaf543-13fb-5ac3-9c64-38289c00e187")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 259.08 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D4_DQS_c"
+		(shape input)
+		(at 177.8 261.62 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "57bce495-6c03-59a9-a612-aa698781ee90")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 261.62 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D4_DQS_t"
+		(shape input)
+		(at 177.8 264.16 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2c2655a8-0ecc-51b9-b318-0cd8feb88211")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 264.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 266.7 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4997cf94-be23-59a1-b012-4209c4064853")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 266.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D4_DQ7"
+		(shape input)
+		(at 177.8 269.24 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "670bd921-25a7-54ab-9767-15e8371dc0e8")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 269.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 271.78 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "de92fb53-0a9b-5c83-be41-b207e0a76086")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 271.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D4_DQ3"
+		(shape input)
+		(at 177.8 274.32 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9bbfe084-3739-525d-87ac-b0db03467502")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 274.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 276.86 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2fb616bf-23a3-5135-8582-e45d2e128de2")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 276.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D5_DQ5"
+		(shape input)
+		(at 177.8 279.4 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "bc9d401a-38e4-5624-81c6-5a039ca29bb5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 279.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 281.94 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "948dcefe-5cd1-5276-ae26-69ae6fbfc841")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 281.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D5_DQ1"
+		(shape input)
+		(at 177.8 284.48 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1dd85e41-3cf6-5397-9e9c-1b97bcee3eaf")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 284.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 287.02 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8a4fcaf7-c08b-54a4-8b27-451489f2fee0")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 287.02 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D5_DQS_c"
+		(shape input)
+		(at 177.8 289.56 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e4848140-9c85-59f3-a9c5-c88363be16a7")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 289.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D5_DQS_t"
+		(shape input)
+		(at 177.8 292.1 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8e9d8306-77e3-5492-9a40-664bb8ff7311")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 292.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 294.64 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4536f934-4e0c-5133-80a3-00255d5b48ba")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 294.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D5_DQ7"
+		(shape input)
+		(at 177.8 297.18 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "85335450-596a-5dec-bbe1-89e75804f2b7")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 297.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 299.72 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "fdb00724-fadc-5420-af9d-2b73c9df712c")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 299.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D5_DQ3"
+		(shape input)
+		(at 177.8 302.26 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a23ef89e-f564-5ac3-a918-10e0a241f119")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 302.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 304.8 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0d2e7e40-e69b-5409-96f6-e7b2b7584337")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 304.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D6_DQ5"
+		(shape input)
+		(at 177.8 307.34 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "86fbf345-60dc-5b5b-8919-3b3257a76ce0")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 307.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 309.88 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "941a080c-97f4-51ec-b651-01377ffefb6d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 309.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D6_DQ1"
+		(shape input)
+		(at 177.8 312.42 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8e50e10a-2af7-5060-a760-b75cc19dacda")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 312.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 314.96 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "91197397-8fa9-52c0-9bd5-04967e8b1fd7")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 314.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D6_DQS_c"
+		(shape input)
+		(at 177.8 317.5 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f1eee9bd-42ee-535a-9d35-cb2c4525e70f")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 317.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D6_DQS_t"
+		(shape input)
+		(at 177.8 320.04 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "afaadc72-5679-5705-8937-54bf40a91ea0")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 320.04 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 322.58 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "73ee0f03-264c-570a-8f56-10696356c5c9")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 322.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D6_DQ7"
+		(shape input)
+		(at 177.8 325.12 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e6eb3f09-c63e-5265-a4a7-df91f1438b7b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 325.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 327.66 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "643e453c-d90c-509d-96ce-9b2d9c0e09cb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 327.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D6_DQ3"
+		(shape input)
+		(at 177.8 330.2 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "524a7c78-33b1-5ae7-9b9c-863159acf11c")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 330.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 332.74 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "3ef59e3d-ade5-5292-a078-2c2f2474d1c6")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 332.74 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D7_DQ5"
+		(shape input)
+		(at 177.8 335.28 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0b9922db-c08b-513f-a20c-ceedda06247a")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 335.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 337.82 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "b7efea88-cf45-5625-aaef-c2993cc8b196")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 337.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D7_DQ1"
+		(shape input)
+		(at 177.8 340.36 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2a529155-7ac0-5f6c-9b63-64886da7f470")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 340.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 342.9 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f0ddef67-e842-590e-93d8-00a3d24aea91")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 342.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D7_DQS_c"
+		(shape input)
+		(at 177.8 345.44 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f6cb3b36-42e5-567d-9063-7f74eb285cc5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 345.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D7_DQS_t"
+		(shape input)
+		(at 177.8 347.98 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a4422572-c22d-5107-a9d1-a1dee28c1423")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 347.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 350.52 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "63826616-374f-5cc8-b261-53b5366d8ec6")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 350.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D7_DQ7"
+		(shape input)
+		(at 177.8 353.06 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "201e8409-8b71-51d3-8604-636838e55cac")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 353.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 355.6 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a3e2637e-717c-572f-a295-20dfb05c20c8")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 355.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "D7_DQ3"
+		(shape input)
+		(at 177.8 358.14 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "7062adb2-3887-530b-9585-20f30100e404")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 358.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "GND"
+		(shape input)
+		(at 177.8 360.68 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "dc9d8f76-6b5f-5da1-9aa6-394174eb17fc")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 360.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VDDSPD"
+		(shape input)
+		(at 177.8 363.22 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "224cb32d-7fa7-51be-aba1-f3a756ff59ef")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 363.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "SPD_SDA"
+		(shape input)
+		(at 177.8 365.76 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "16762f8a-ac32-524b-a181-e544a3f27e42")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 365.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VPP"
+		(shape input)
+		(at 177.8 368.3 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "c54a0957-50d5-54de-a4a1-2ca7c826abe4")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 368.3 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VPP"
+		(shape input)
+		(at 177.8 370.84 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d986ecf4-d230-5303-b7d9-a1c8f4604442")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 370.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "VPP"
+		(shape input)
+		(at 177.8 373.38 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "cd20bdff-eb6d-51fc-ad77-ceef3b678ebb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 180.34 373.38 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(symbol
+		(lib_id "omi:DDR4_UDIMM_288_Edge")
+		(at 152.4 190.5 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "add96d41-c241-522b-a8f9-fc851009ac2f")
+		(property "Reference" "J1"
+			(at 132.08 2.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DDR4_UDIMM_288_Edge"
+			(at 132.08 381 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 152.4 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 152.4 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c1661eb1-040a-54e8-81d1-c8bce74e134b")
+		)
+		(pin "2"
+			(uuid "2013ce6d-c2c9-5cdd-add8-82df6da2084a")
+		)
+		(pin "3"
+			(uuid "c047166a-38db-5aa1-a8ec-e7925133ae2b")
+		)
+		(pin "4"
+			(uuid "63bed500-c902-5fef-abeb-97c44d992219")
+		)
+		(pin "5"
+			(uuid "886a63cf-ba1c-5a49-a019-90decccfc216")
+		)
+		(pin "6"
+			(uuid "8f76ba69-2e28-5181-81fc-501d119a6f2f")
+		)
+		(pin "7"
+			(uuid "aef1a120-9978-5135-bf59-1581095dbfd2")
+		)
+		(pin "8"
+			(uuid "009e7f7b-bab6-5635-843f-8974010d2ae5")
+		)
+		(pin "9"
+			(uuid "e8f83e99-71aa-548a-bbae-3c0a2af02386")
+		)
+		(pin "10"
+			(uuid "ae28c59e-d1d9-5bc4-aeb6-e68858ed7536")
+		)
+		(pin "11"
+			(uuid "9b5e6f3e-1043-5753-9c37-c218a675373c")
+		)
+		(pin "12"
+			(uuid "37ddca59-c0e5-55f5-a110-2c4246e38bf3")
+		)
+		(pin "13"
+			(uuid "6a352328-e609-5e11-8d64-ae3d05d65770")
+		)
+		(pin "14"
+			(uuid "a7c9c9a6-aa12-5ed4-83f3-2af764c2356a")
+		)
+		(pin "15"
+			(uuid "98d93b82-7738-5cb6-84ea-805ea3feef14")
+		)
+		(pin "16"
+			(uuid "3f0a5e2a-96fa-502d-884b-062e05928898")
+		)
+		(pin "17"
+			(uuid "c9b38c6d-4744-500b-9669-aa7a7ddd36cb")
+		)
+		(pin "18"
+			(uuid "f1e85282-22fe-5196-9ae8-3fbf601511ff")
+		)
+		(pin "19"
+			(uuid "8413a918-75ba-56ee-b624-82e174e9ef9f")
+		)
+		(pin "20"
+			(uuid "c27e2658-9649-5c00-9905-39b2efde3e2c")
+		)
+		(pin "21"
+			(uuid "f4302316-1f92-5edb-a726-510652603ab5")
+		)
+		(pin "22"
+			(uuid "b95f59e9-987a-52b3-bbe3-34144646ea02")
+		)
+		(pin "23"
+			(uuid "22fd037a-62fd-5de7-ba10-42e41a0487be")
+		)
+		(pin "24"
+			(uuid "e60158ff-4bde-5c96-8f7c-74a5e1080ff9")
+		)
+		(pin "25"
+			(uuid "d083f089-3e03-5aec-a625-e366bc343317")
+		)
+		(pin "26"
+			(uuid "9ad68daf-f888-5c3d-9085-fa5476dfc7f8")
+		)
+		(pin "27"
+			(uuid "d0f4d127-c610-535b-a6df-b62d0c22aba6")
+		)
+		(pin "28"
+			(uuid "1896f22c-692e-5e97-bc6a-607d96db7882")
+		)
+		(pin "29"
+			(uuid "df4220cb-c2c0-5119-8383-50c3c92bf965")
+		)
+		(pin "30"
+			(uuid "669f9cc4-593b-5daf-9936-78866410b30a")
+		)
+		(pin "31"
+			(uuid "b856efd4-c426-5884-8dd5-6fbdad00bf45")
+		)
+		(pin "32"
+			(uuid "2909fe69-0280-5bbe-9adc-84e894711341")
+		)
+		(pin "33"
+			(uuid "f004efaa-3101-50ea-b125-5a1e799744e8")
+		)
+		(pin "34"
+			(uuid "4933071e-7af0-5ffd-96d0-8bdf52423c6c")
+		)
+		(pin "35"
+			(uuid "85c9a1df-fb9d-5c9f-bd82-749b77802f73")
+		)
+		(pin "36"
+			(uuid "9370dd54-87a1-5872-b93a-ef867a99f93c")
+		)
+		(pin "37"
+			(uuid "5e2f5c0d-730b-54ca-bd49-ceb7fc4af304")
+		)
+		(pin "38"
+			(uuid "3b1ae010-4897-5fac-80f6-86a010cb0e6b")
+		)
+		(pin "39"
+			(uuid "ee7abdc7-45dd-56e9-a33f-491c73362f6f")
+		)
+		(pin "40"
+			(uuid "36bfc9ed-663d-57c7-93d2-fc8c86572e49")
+		)
+		(pin "41"
+			(uuid "d73ab86e-3a00-5569-a14c-18bf252a49ab")
+		)
+		(pin "42"
+			(uuid "fbb0e090-6c61-5632-8f37-6900100c127e")
+		)
+		(pin "43"
+			(uuid "60ad0838-d15c-5daf-bfc3-e7fcebc9fe09")
+		)
+		(pin "44"
+			(uuid "ad1be44d-37c6-566c-a220-ac63d66d94d6")
+		)
+		(pin "45"
+			(uuid "af3ae709-f791-5994-823d-c2bf97cdd3ba")
+		)
+		(pin "46"
+			(uuid "7d461dcc-7ffe-556b-bb39-c740c8bda116")
+		)
+		(pin "47"
+			(uuid "3052f2e9-cb23-5e65-8805-6542ef5ff6a1")
+		)
+		(pin "48"
+			(uuid "001755e4-f6f7-5b81-975b-ea20104c896f")
+		)
+		(pin "49"
+			(uuid "0dae81ea-258d-530d-a348-c53f9ec75d77")
+		)
+		(pin "50"
+			(uuid "0c589bc2-fb13-5b70-99ff-3588d272c831")
+		)
+		(pin "51"
+			(uuid "57cf3c48-739b-5f65-95e1-761a8426bbce")
+		)
+		(pin "52"
+			(uuid "696b0ae8-0432-5df1-a7f3-4932b162bd0b")
+		)
+		(pin "53"
+			(uuid "719c850f-4a5d-54f1-8523-b7e7bbc993fd")
+		)
+		(pin "54"
+			(uuid "57b8fc5e-2518-5ffc-9a71-057f8b1e3848")
+		)
+		(pin "55"
+			(uuid "3020860f-c97f-5264-859e-75d61337fded")
+		)
+		(pin "56"
+			(uuid "83b46665-9fcc-5688-9a4d-c266f70c3093")
+		)
+		(pin "57"
+			(uuid "7ce50fdc-70fc-54b8-bdc9-e2e190f0ce43")
+		)
+		(pin "58"
+			(uuid "a7656b6a-04ac-5957-953f-df9268953715")
+		)
+		(pin "59"
+			(uuid "b0744e64-281f-5d24-ac02-a89b04641a7a")
+		)
+		(pin "60"
+			(uuid "bb9d57f5-b216-5a2a-86f8-4e6eaae3ec3e")
+		)
+		(pin "61"
+			(uuid "178ba462-3d87-561d-b2db-46c1b2522a05")
+		)
+		(pin "62"
+			(uuid "eea9d56d-5854-55cd-9c14-0302988fbb50")
+		)
+		(pin "63"
+			(uuid "0f301830-f21c-5029-99db-eeb431a16811")
+		)
+		(pin "64"
+			(uuid "447ad415-95da-5795-aa3b-36b97510e581")
+		)
+		(pin "65"
+			(uuid "d9135546-30c5-5040-a24e-606b3fd26f92")
+		)
+		(pin "66"
+			(uuid "a7585381-cc67-5d58-ac5e-37a5230c0eb7")
+		)
+		(pin "67"
+			(uuid "da5b4074-2787-56dc-902a-77b82ca1b41a")
+		)
+		(pin "68"
+			(uuid "2df09444-21e2-5faf-9b58-f93c3d033a89")
+		)
+		(pin "69"
+			(uuid "e0fff671-263b-5be0-8ffc-c3ca9055d28f")
+		)
+		(pin "70"
+			(uuid "3953162a-e5da-594c-82ec-f6b4bd3c56a8")
+		)
+		(pin "71"
+			(uuid "0b4a4a58-b6a7-5062-ba1c-24c70b648c67")
+		)
+		(pin "72"
+			(uuid "ad22cca4-843e-50d4-aec9-4e3a2f2976a7")
+		)
+		(pin "73"
+			(uuid "ed6dd35f-34c6-55ba-9479-8b4428a2598a")
+		)
+		(pin "74"
+			(uuid "c70b74ec-919e-5d1e-bf6e-05a0a74eb660")
+		)
+		(pin "75"
+			(uuid "f13830a3-96ba-5dd9-8c37-28c632643171")
+		)
+		(pin "76"
+			(uuid "9fa08773-abdb-5bee-bd10-3c923cfd6b3f")
+		)
+		(pin "77"
+			(uuid "becdb699-5798-5dfe-921a-58b6af34783f")
+		)
+		(pin "78"
+			(uuid "bba9c6e0-65fa-51d7-9574-f9b45c045f1c")
+		)
+		(pin "79"
+			(uuid "3f6e9dbf-999a-5f41-a6e8-bfe6a1ca3dd1")
+		)
+		(pin "80"
+			(uuid "a833ef88-3643-5828-903b-d0f7b43bc8a5")
+		)
+		(pin "81"
+			(uuid "f1fd45aa-35b5-5c2d-a995-da9fadb2db99")
+		)
+		(pin "82"
+			(uuid "7e3816b7-266d-513a-bb6d-5da7cce6d905")
+		)
+		(pin "83"
+			(uuid "d331d550-e68c-5877-8d90-790a4302219a")
+		)
+		(pin "84"
+			(uuid "3cd4d087-a61c-5c17-b3c7-9b98c17fbca4")
+		)
+		(pin "85"
+			(uuid "484fa1a4-d109-555a-9cda-f63a336800cb")
+		)
+		(pin "86"
+			(uuid "bf31665b-8604-53c3-b064-8ae0ded74f54")
+		)
+		(pin "87"
+			(uuid "b0854ef1-6591-5a87-adb6-e42994456681")
+		)
+		(pin "88"
+			(uuid "8638a523-fc99-515f-8e1b-3713a25c30b9")
+		)
+		(pin "89"
+			(uuid "15961d50-71c8-51e0-8e39-bc41b9666c68")
+		)
+		(pin "90"
+			(uuid "4f9152c7-909d-56ea-b315-b10e0c8e9d9c")
+		)
+		(pin "91"
+			(uuid "f7afad70-64ff-5052-8c15-6ec21ce57b35")
+		)
+		(pin "92"
+			(uuid "8989879c-5440-509d-8072-856e58149b2b")
+		)
+		(pin "93"
+			(uuid "bc390a5f-5415-5c9a-8744-07fb18eaa8fa")
+		)
+		(pin "94"
+			(uuid "c4283588-1420-5b5e-aab7-fea2b423e6b2")
+		)
+		(pin "95"
+			(uuid "f23881dc-db78-5e79-85e8-a321f8a41239")
+		)
+		(pin "96"
+			(uuid "72998947-c3f7-50d6-b880-e9fc8a7ab766")
+		)
+		(pin "97"
+			(uuid "61530e61-2fd9-528b-9ffd-a69e441bc022")
+		)
+		(pin "98"
+			(uuid "6f40362f-d73b-59e6-a6e8-1bee64c7d633")
+		)
+		(pin "99"
+			(uuid "46fa4962-45af-5939-8e0a-a8f6ec31ce21")
+		)
+		(pin "100"
+			(uuid "2a4878c7-3e1b-518c-9fc0-ae77a01f05a2")
+		)
+		(pin "101"
+			(uuid "5cde6602-d424-5a54-91c1-7655e442c925")
+		)
+		(pin "102"
+			(uuid "0b4e3684-0d3e-59ec-be07-13e4113d3e79")
+		)
+		(pin "103"
+			(uuid "329d213c-748f-578d-8fc2-99eb165e961e")
+		)
+		(pin "104"
+			(uuid "901c21de-883f-5703-9b1f-210a26d9a097")
+		)
+		(pin "105"
+			(uuid "c267fb69-3928-5d87-ae33-a77d73759732")
+		)
+		(pin "106"
+			(uuid "ed492b60-4e89-54af-a402-8cd6eb2cd2d1")
+		)
+		(pin "107"
+			(uuid "37601f44-c593-5df7-a9e6-9bf3ae7f705c")
+		)
+		(pin "108"
+			(uuid "ae5c3538-7b64-542d-a541-db5792e4d582")
+		)
+		(pin "109"
+			(uuid "1a3fddcd-00d0-511e-a473-7b150244cd27")
+		)
+		(pin "110"
+			(uuid "0b9d344f-a564-54df-ba4c-6a1eebcd1b37")
+		)
+		(pin "111"
+			(uuid "62400e96-3877-5a55-80a9-004ac074bf0e")
+		)
+		(pin "112"
+			(uuid "5fb3f6eb-cc90-512b-b361-627039f5910d")
+		)
+		(pin "113"
+			(uuid "6e64b1c3-ba8a-535b-a3bc-14bd48a71927")
+		)
+		(pin "114"
+			(uuid "32913d85-ff02-561a-bb70-7ad0f4d1fef4")
+		)
+		(pin "115"
+			(uuid "612168bb-9f7a-5536-9469-03e1192a1a59")
+		)
+		(pin "116"
+			(uuid "8260ff50-c815-5888-b68d-04ecf25b5b48")
+		)
+		(pin "117"
+			(uuid "8b3fdaa0-0223-52e2-8542-8495ad28a57d")
+		)
+		(pin "118"
+			(uuid "c0c63d37-10f3-5ab8-ab61-fd700b450d86")
+		)
+		(pin "119"
+			(uuid "811ce391-7e47-5c65-b1d1-9d94228a6f38")
+		)
+		(pin "120"
+			(uuid "34719d47-ebc0-5e37-a4c7-7da767ed148b")
+		)
+		(pin "121"
+			(uuid "3e532ea3-fc18-5718-8ea0-47feee84267c")
+		)
+		(pin "122"
+			(uuid "81bcad3a-650a-5d40-9c47-10f54acfe494")
+		)
+		(pin "123"
+			(uuid "d47da4dc-0ffe-5165-84a7-4850d0e46610")
+		)
+		(pin "124"
+			(uuid "ccc4665f-635e-58a2-bf89-b0c7ee5f2ebc")
+		)
+		(pin "125"
+			(uuid "386df909-0ede-5b98-be02-561f19c3eff2")
+		)
+		(pin "126"
+			(uuid "4afec6fd-bed4-55ce-8ecc-4aa6ff8bee98")
+		)
+		(pin "127"
+			(uuid "5c79bdc7-f654-5e18-9058-498d9a409a3f")
+		)
+		(pin "128"
+			(uuid "0b49160d-438c-57c5-bba9-37dc2291428b")
+		)
+		(pin "129"
+			(uuid "7ab3f9e0-8e38-5b64-891b-91f438b28024")
+		)
+		(pin "130"
+			(uuid "be88e28b-3f72-58dc-b6f3-ce034294f396")
+		)
+		(pin "131"
+			(uuid "3422d12b-5651-5876-aa89-d8d4295f44a9")
+		)
+		(pin "132"
+			(uuid "0c9b70b6-abde-5dc3-b079-8afb6f477afe")
+		)
+		(pin "133"
+			(uuid "528ffbca-827d-532d-8195-ebd8df5f5b77")
+		)
+		(pin "134"
+			(uuid "4276cc8c-e126-5dff-a9f9-322fb80e57d6")
+		)
+		(pin "135"
+			(uuid "d6d67517-862c-5967-9318-9e5dd5376267")
+		)
+		(pin "136"
+			(uuid "f51af0f3-8b56-5e73-b9f9-a2a6512eeaa0")
+		)
+		(pin "137"
+			(uuid "5a0f24d1-9113-5d4f-accd-b3a4629b1c87")
+		)
+		(pin "138"
+			(uuid "20f66146-70f5-5a2b-952e-359bd5195be9")
+		)
+		(pin "139"
+			(uuid "31f9c361-50f7-51fb-b55a-430821810804")
+		)
+		(pin "140"
+			(uuid "9c2c1c3b-73d5-5bc4-90ec-7572c5f9f0ce")
+		)
+		(pin "141"
+			(uuid "70757de1-87ba-5dc2-93bf-6d09e583b6fb")
+		)
+		(pin "142"
+			(uuid "bdf186cb-081d-51af-a6b2-310fcda9f7e8")
+		)
+		(pin "143"
+			(uuid "c1aae950-422a-549c-9a4a-ea333d1ffcbf")
+		)
+		(pin "144"
+			(uuid "d5936b34-e428-5631-a7f7-88e053008a8b")
+		)
+		(pin "145"
+			(uuid "5c517fe4-6585-5daf-bd6d-2d5a63733131")
+		)
+		(pin "146"
+			(uuid "7ef3abe8-681b-5757-943e-00cfc4d3f225")
+		)
+		(pin "147"
+			(uuid "3f666f42-e800-5243-9f7e-53f78ae9491a")
+		)
+		(pin "148"
+			(uuid "36e18f9c-859f-5e10-a407-d3d0d155b526")
+		)
+		(pin "149"
+			(uuid "5cd31241-515c-57d9-8608-94740d408a7d")
+		)
+		(pin "150"
+			(uuid "dd2a6d7f-6fcb-5b76-a253-c3752ea47cd5")
+		)
+		(pin "151"
+			(uuid "e3dad433-05f6-551e-8953-bc4e6bffb877")
+		)
+		(pin "152"
+			(uuid "9e8883da-aa0c-5fa0-8f27-e5f1b773e07b")
+		)
+		(pin "153"
+			(uuid "9b2dfff3-b480-53c4-ad48-6ae790d57829")
+		)
+		(pin "154"
+			(uuid "ef66dbb2-2a53-5677-bbb4-7a4c0a3d969e")
+		)
+		(pin "155"
+			(uuid "e8ae0097-0c76-5121-be07-5e362c135471")
+		)
+		(pin "156"
+			(uuid "ad1da2a2-78ac-5d4b-bf91-923e730246c4")
+		)
+		(pin "157"
+			(uuid "65c14603-2b7d-515b-896d-479e0bbed1b2")
+		)
+		(pin "158"
+			(uuid "1c05b615-249d-5f43-89cc-a1d7d2167bcc")
+		)
+		(pin "159"
+			(uuid "bb97adea-187c-52d2-a663-56260b0a2dfd")
+		)
+		(pin "160"
+			(uuid "5e73da2b-8985-5108-ba4f-1e375d2b9e61")
+		)
+		(pin "161"
+			(uuid "6221c8cc-8dc6-5c63-8615-dbd0711048aa")
+		)
+		(pin "162"
+			(uuid "1c8aeb94-0de1-57bd-a59e-b479fd3130c1")
+		)
+		(pin "163"
+			(uuid "6c59985e-8754-5259-9a66-7fbb9d4e029d")
+		)
+		(pin "164"
+			(uuid "4b4512a4-46fc-535f-bf61-2b3d426dcc1d")
+		)
+		(pin "165"
+			(uuid "67619a35-b66e-5d1a-bdd4-b286d7d18c5a")
+		)
+		(pin "166"
+			(uuid "3d6e2fd4-b31f-5282-8c80-b5265869a82a")
+		)
+		(pin "167"
+			(uuid "45a5e76f-147d-5c20-90fb-d86b655a26fd")
+		)
+		(pin "168"
+			(uuid "d22a1e01-1178-5520-8eb6-958407d854ca")
+		)
+		(pin "169"
+			(uuid "17c81fc5-f97c-58fc-b841-0086adc64bca")
+		)
+		(pin "170"
+			(uuid "1d844210-a9e2-5dbb-bf3e-8cd14e3a5026")
+		)
+		(pin "171"
+			(uuid "43b46aef-7ac8-5db5-b1d8-6d18da36f7b0")
+		)
+		(pin "172"
+			(uuid "ba9691e7-86d9-551e-84f8-2b6c93590e58")
+		)
+		(pin "173"
+			(uuid "d8bee422-83ed-5d01-a866-2fa09d32f31b")
+		)
+		(pin "174"
+			(uuid "7027ad65-8dec-5fbd-a241-014ead225a9d")
+		)
+		(pin "175"
+			(uuid "cbfb826d-f2bc-51d8-ac0b-6d1e38afa83d")
+		)
+		(pin "176"
+			(uuid "9fb2c9a8-04cc-54cb-8605-5b2c379bb76f")
+		)
+		(pin "177"
+			(uuid "cd5e61db-181d-5ea5-a152-3fe1612ed1d2")
+		)
+		(pin "178"
+			(uuid "15d195d5-e9d8-508f-9dfe-b6e91c7d7ffc")
+		)
+		(pin "179"
+			(uuid "59c6aa84-cd02-5477-a069-3b792c0ac751")
+		)
+		(pin "180"
+			(uuid "27971f06-1541-5733-a22b-6029efe4bbfc")
+		)
+		(pin "181"
+			(uuid "3af33a32-c480-5f3b-8d83-5e17a65e0d46")
+		)
+		(pin "182"
+			(uuid "83fc8092-85d8-5d5b-96ed-565b67819757")
+		)
+		(pin "183"
+			(uuid "b54d1d45-6f1b-569b-99fb-d0bcf1b237fe")
+		)
+		(pin "184"
+			(uuid "32be8e21-43be-5250-aeaf-ffd436c0a95e")
+		)
+		(pin "185"
+			(uuid "e674c8fe-5ad6-5509-a5f5-248f54f04277")
+		)
+		(pin "186"
+			(uuid "166bcfeb-dba8-55c7-b57d-7bd703c3bb9f")
+		)
+		(pin "187"
+			(uuid "409e49c8-d7ed-5f29-8d73-e3c946c01e26")
+		)
+		(pin "188"
+			(uuid "4868377d-1fbb-51f6-83aa-ab240ddadb27")
+		)
+		(pin "189"
+			(uuid "ea18b07d-d8db-542e-8d57-16636dbdbb68")
+		)
+		(pin "190"
+			(uuid "03b3fca0-bebf-5a6c-94f1-7ca2705eba5a")
+		)
+		(pin "191"
+			(uuid "7b502ed3-0ca1-50fc-be62-8e68bb3433f1")
+		)
+		(pin "192"
+			(uuid "161fc7a3-dfb1-5d88-bd6f-4bc9aa3badca")
+		)
+		(pin "193"
+			(uuid "92d8661b-a5c8-5cf2-9925-cd954786a04f")
+		)
+		(pin "194"
+			(uuid "7597db77-0a10-5c8f-b78f-34714c1290f3")
+		)
+		(pin "195"
+			(uuid "9bee1e57-9ad8-52f3-aa2d-a5d664c559c0")
+		)
+		(pin "196"
+			(uuid "0aba134e-ac7f-597a-959e-4f53710ca3a2")
+		)
+		(pin "197"
+			(uuid "26ba5cd2-0aa5-5104-b1e7-c933c03381c5")
+		)
+		(pin "198"
+			(uuid "df4e16c3-5e11-5e78-8df6-f0a42edd6ddb")
+		)
+		(pin "199"
+			(uuid "3c91d34d-a4d2-530f-a6b4-7f76cce6e32d")
+		)
+		(pin "200"
+			(uuid "73d4c811-f23d-5bcd-9851-c81ed69f3491")
+		)
+		(pin "201"
+			(uuid "d451a865-3fbd-5e47-bc83-c1c013079547")
+		)
+		(pin "202"
+			(uuid "55f1eabd-def8-5540-b72d-df0206da493d")
+		)
+		(pin "203"
+			(uuid "ffff606b-dc2c-5171-a8ec-0f435eeeebf2")
+		)
+		(pin "204"
+			(uuid "d10c76cb-109c-598b-aecf-d31886318f54")
+		)
+		(pin "205"
+			(uuid "68f059a6-b115-520d-b4a3-96f0fe9de578")
+		)
+		(pin "206"
+			(uuid "f8256947-8b84-5f77-a6a9-0745493a03d2")
+		)
+		(pin "207"
+			(uuid "edd36aba-26ed-5683-b642-21e90d444d3a")
+		)
+		(pin "208"
+			(uuid "5e313a3e-dc24-5823-aa5b-eb24d372108f")
+		)
+		(pin "209"
+			(uuid "22899a36-41e0-582c-b9a7-b651254de5f5")
+		)
+		(pin "210"
+			(uuid "15bf8eb1-21c1-5ffe-b951-d78d5e6fa6ad")
+		)
+		(pin "211"
+			(uuid "5b6c497d-fcbc-534c-9b12-6d98c499002c")
+		)
+		(pin "212"
+			(uuid "8ed8003e-4485-5698-856f-19087a20df3d")
+		)
+		(pin "213"
+			(uuid "07e56c30-108d-52b4-aabb-6f6d87003a5a")
+		)
+		(pin "214"
+			(uuid "e5f84b7e-c7e1-512b-856f-e3b1753c8d33")
+		)
+		(pin "215"
+			(uuid "84ffc7ff-e242-518f-aafd-34da02dc6b0f")
+		)
+		(pin "216"
+			(uuid "384202cd-73c0-5e96-874a-87aa40587579")
+		)
+		(pin "217"
+			(uuid "1b7c8232-468c-5fa3-8cac-6389140c2469")
+		)
+		(pin "218"
+			(uuid "c9794cb7-a85b-5283-bbd5-74e72d7e2fe2")
+		)
+		(pin "219"
+			(uuid "19425905-78e6-5742-9e04-95921140d9a0")
+		)
+		(pin "220"
+			(uuid "0ec8292c-92ff-5555-8c7d-8fe1566654a1")
+		)
+		(pin "221"
+			(uuid "f2224fd4-88e3-5b18-b027-1bf8aa20cc69")
+		)
+		(pin "222"
+			(uuid "25191e62-f4b0-59b6-93be-5f519ed2b7d7")
+		)
+		(pin "223"
+			(uuid "4b9ba538-d186-5112-aea8-42d11de0c367")
+		)
+		(pin "224"
+			(uuid "f90f3b79-faec-5480-aa17-a68411521bce")
+		)
+		(pin "225"
+			(uuid "7266fe24-5487-503c-8f9f-aa6d46dc3279")
+		)
+		(pin "226"
+			(uuid "72691cf3-ef92-5dfd-b721-634114a73fea")
+		)
+		(pin "227"
+			(uuid "5483d943-6e7c-5627-ba66-8b5c0ab78ff8")
+		)
+		(pin "228"
+			(uuid "cbf308cf-2787-58f3-9de6-6c85e18aa271")
+		)
+		(pin "229"
+			(uuid "0caac947-b4ea-598b-9165-ab0979c817cc")
+		)
+		(pin "230"
+			(uuid "e17d5ced-390c-5d45-8552-2d85bedbd065")
+		)
+		(pin "231"
+			(uuid "37847ce7-f54e-5025-b4f7-f0ff872a9088")
+		)
+		(pin "232"
+			(uuid "d00f51c3-821e-51da-a814-ebd5b00c9fd0")
+		)
+		(pin "233"
+			(uuid "dc07a9df-307a-5784-a259-f59f2306e1c2")
+		)
+		(pin "234"
+			(uuid "38e557a6-6250-52fc-84b5-d8d5ac58dd9e")
+		)
+		(pin "235"
+			(uuid "f1be0f38-317a-58e9-ae53-d7e672fd3ad8")
+		)
+		(pin "236"
+			(uuid "baebf0a0-1236-5965-8665-4bef5365441e")
+		)
+		(pin "237"
+			(uuid "5843a379-3dec-52eb-867c-9bf83fed6883")
+		)
+		(pin "238"
+			(uuid "38e86301-9ca0-5f5d-8df1-f20573eba3d9")
+		)
+		(pin "239"
+			(uuid "84052b06-9b72-5833-bb41-64288fd0f230")
+		)
+		(pin "240"
+			(uuid "cb348a72-1649-593c-b647-bebcbe475b4b")
+		)
+		(pin "241"
+			(uuid "20d6f70d-4acc-5db4-b3e0-16bd5cf24d9a")
+		)
+		(pin "242"
+			(uuid "d2c0e98d-1186-563f-ab13-04c103f494be")
+		)
+		(pin "243"
+			(uuid "0fc379d5-4c8c-51fd-a7d3-a7d9696d362d")
+		)
+		(pin "244"
+			(uuid "c4c1a14a-75bf-5737-ac00-7a7695643928")
+		)
+		(pin "245"
+			(uuid "832e168c-6f5e-552b-8993-22eb48a1202b")
+		)
+		(pin "246"
+			(uuid "33e9ba8f-ee1f-51ff-a7f1-2ec4765020c8")
+		)
+		(pin "247"
+			(uuid "bcb86106-147c-5d6d-9ed4-0aaa349359df")
+		)
+		(pin "248"
+			(uuid "866cae38-afc8-5cc6-8fee-261296dd7194")
+		)
+		(pin "249"
+			(uuid "1d4535e3-2421-545e-8017-56686b1902c6")
+		)
+		(pin "250"
+			(uuid "07793621-fe88-5703-9f26-7fd78930355a")
+		)
+		(pin "251"
+			(uuid "855f6a6e-3759-541e-b85d-20ce9294b885")
+		)
+		(pin "252"
+			(uuid "04ee4834-695b-52b8-887f-1ec8a54004dc")
+		)
+		(pin "253"
+			(uuid "f6dcc300-0ce4-5926-9a32-52304dbf1c69")
+		)
+		(pin "254"
+			(uuid "7722d27a-d1de-5fa2-b39b-8453eb79a867")
+		)
+		(pin "255"
+			(uuid "ebc61174-53de-5c19-b393-5b99ac7aa277")
+		)
+		(pin "256"
+			(uuid "3e6bbada-5d05-55a2-9ff2-da7b2c6272c5")
+		)
+		(pin "257"
+			(uuid "3ca5315b-0d3b-5a46-b930-984268a604fd")
+		)
+		(pin "258"
+			(uuid "a57cd4ef-f75b-5e3b-97a8-abaacbfa79f3")
+		)
+		(pin "259"
+			(uuid "d21741c0-a81a-5401-88f4-41baec801028")
+		)
+		(pin "260"
+			(uuid "08f89661-66c0-56c0-9777-09bb966b9640")
+		)
+		(pin "261"
+			(uuid "3193562f-9ce4-5a96-ad43-8ee0e35dcce4")
+		)
+		(pin "262"
+			(uuid "36ecfa03-e011-52d2-a52a-7bf9a2e347a1")
+		)
+		(pin "263"
+			(uuid "9bf203ff-f847-5854-ae86-ec6286ea3cab")
+		)
+		(pin "264"
+			(uuid "f36fc030-5e0b-5da9-8813-e7dfa9e81fc2")
+		)
+		(pin "265"
+			(uuid "43898412-4f42-5a20-b816-64566a803fc1")
+		)
+		(pin "266"
+			(uuid "3b337d99-e3c9-59fb-a68d-82677d93bec7")
+		)
+		(pin "267"
+			(uuid "894e0707-a097-54fe-9e72-89e0726817cc")
+		)
+		(pin "268"
+			(uuid "9d275170-197f-57a3-8a6c-75f920115fb1")
+		)
+		(pin "269"
+			(uuid "e5890b0c-4489-51e1-b519-92e12482dfde")
+		)
+		(pin "270"
+			(uuid "17cc6b4b-ec62-5391-8b47-c97f8a18ce2a")
+		)
+		(pin "271"
+			(uuid "cf49e902-ebc5-59af-b1b4-725c573ac102")
+		)
+		(pin "272"
+			(uuid "d31bcbb9-013c-5085-871f-847704b28117")
+		)
+		(pin "273"
+			(uuid "f033527b-2e94-5813-9364-834e0b112b9b")
+		)
+		(pin "274"
+			(uuid "f9ea7c02-24bd-5b06-a51a-7ae1176b2c41")
+		)
+		(pin "275"
+			(uuid "2243e47d-b474-5cac-adbd-876e671341b2")
+		)
+		(pin "276"
+			(uuid "04a1ea62-a315-5fd3-99d7-c776f0da8f7b")
+		)
+		(pin "277"
+			(uuid "4f44a65d-9fab-5b5b-88b7-0eabeb416a2b")
+		)
+		(pin "278"
+			(uuid "22c0dd8a-fbd5-5fc5-a5a0-68844d1fc16b")
+		)
+		(pin "279"
+			(uuid "e4ba0b99-c10d-505a-ae2e-1e8e58051471")
+		)
+		(pin "280"
+			(uuid "38cc6064-14a6-5093-a14d-a3ec3145ac8b")
+		)
+		(pin "281"
+			(uuid "02606bd8-4149-58c7-b2a7-b5503bbc0b1e")
+		)
+		(pin "282"
+			(uuid "61eb2766-31a4-5cf8-ad1d-991c79dd0779")
+		)
+		(pin "283"
+			(uuid "df35ff0b-c631-5666-a5a1-f779bf45a7e2")
+		)
+		(pin "284"
+			(uuid "fce9c783-d52c-5814-8e55-9333f5a9764f")
+		)
+		(pin "285"
+			(uuid "d276e640-ab9c-599d-a123-6c2d44ec074c")
+		)
+		(pin "286"
+			(uuid "84a71711-9c3a-5810-8770-765af28163d8")
+		)
+		(pin "287"
+			(uuid "a1b643dc-81e8-51d7-bf7a-239f3ea90da0")
+		)
+		(pin "288"
+			(uuid "3f367789-3b4e-5731-9255-70106ed0b94b")
+		)
+		(instances
+			(project "omi_v1_power"
+				(path "/464309c0-e3ad-4428-a43f-e1cf3b7a7d42/9986c6c0-2ac4-474e-a00a-d8203c8bf46f"
+					(reference "J1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(embedded_fonts no)
 )

--- a/docs/implementations/2026-06-01-phase2-edge-symbol.md
+++ b/docs/implementations/2026-06-01-phase2-edge-symbol.md
@@ -1,0 +1,154 @@
+# Phase 2 — 288-pin DDR4 UDIMM edge-connector symbol (generated from CSV)
+
+**Date:** 2026-06-01
+**Branch:** `phase2-edge-symbol`
+**Status:** complete; placement validated end-to-end with `kicad-cli` 9.0.8.
+
+---
+
+## 1. Problem / Motivation
+
+The OMI v1 schematic carries an empty 168-byte skeleton sheet,
+`design/power/omi_v1_power/udimm-edge-interface.kicad_sch`, where the physical 288-pin DDR4
+UDIMM edge connector belongs. Until that connector exists, the host-side interface is
+described only by placeholder connectors and floating `global_label`s, so the design cannot
+be called complete. Hand-drawing a 288-pin part is an error farm; the keystone pinmap CSV
+already encodes the JEDEC pin→net mapping authoritatively. Phase 2 turns that CSV into a
+**generated, validated** KiCad symbol and places one instance on the edge sheet so the
+`omi_net` names line up with the rest of the design.
+
+This is an **additive** phase. It deliberately does **not** fix ERC, remove placeholders,
+reconcile net-name mismatches, or add root sheet-pins — those are Phases 3/5.
+
+## 2. What Changed
+
+| File | Change | Description |
+| --- | --- | --- |
+| `tools/edge_symbol/gen_edge_symbol.py` | **added** | Stdlib-only generator: CSV → `omi.kicad_sym` + populated edge sheet; `--verify` re-parses and diffs against the CSV. |
+| `tools/edge_symbol/README.md` | **added** | How to regenerate and validate. |
+| `design/power/omi_v1_power/omi.kicad_sym` | **added** | Generated symbol library; one symbol `DDR4_UDIMM_288_Edge`, 288 pins. |
+| `design/power/omi_v1_power/sym-lib-table` | **added** | Project symbol-lib table registering the library under nickname `omi`. |
+| `design/power/omi_v1_power/udimm-edge-interface.kicad_sch` | **modified** | The single permitted edit: filled the empty sheet with one `J1` instance + 252 `global_label`s. |
+| `build/p2/erc_after.json`, `build/p2/netlist_after.xml` | **added** | Measured post-placement evidence. |
+
+No other existing file was touched: the four other sheets, the CSV, the `.kicad_pcb`, the
+validation scripts, and the evidence tree are all unchanged.
+
+## 3. Implementation Approach
+
+**Inspection first (read-only fan-out).** Four parallel agents established: the CSV schema
+(`pin,symbol,omi_net,group,notes`, 288 unique rows, NC predicate `omi_net == "NC"`); the
+dominant label type (`global_label`, 452 vs 18 local, 0 hierarchical); a free connector ref
+(`J1`); and the KiCad 9 `.kicad_sym` s-expression shape (confirmed from the installed stock
+`Connector_Generic.kicad_sym`). The hierarchy facts (project `omi_v1_power`, root UUID, edge
+sheet-node UUID) were read directly from the root sheet.
+
+**Generation.** The generator reads the CSV (the single source of truth), validates it
+(288 contiguous unique pins, no empty fields), and emits:
+
+* a symbol library whose one symbol lays the 288 pins in two 144-pin columns on a 2.54 mm
+  (100 mil) pitch — pins 1–144 exit left, 145–288 exit right;
+* a populated edge sheet that embeds the symbol, places one `J1` instance, and drops a
+  `global_label` (carrying the `omi_net`) exactly on every non-NC pin's connection point.
+
+**Electrical typing.** `no_connect` when `omi_net == "NC"`; `passive` otherwise (power/ground
+included — see Design Decisions). Histogram: **36 `no_connect`, 252 `passive`**.
+
+**Determinism.** Every UUID is `uuid.uuid5(fixed_namespace, name)`; there are no timestamps
+or RNG, so regeneration is byte-identical (verified by diff).
+
+## 4. Mathematical / Geometric Details
+
+Connectivity here is pure coordinate geometry, so it is worth stating precisely.
+
+**Pin connection point.** In a KiCad symbol a pin `(at x y a)` has its *electrical
+connection point* at exactly `(x, y)` in symbol-local coordinates, regardless of the stem
+angle `a` (the stem is drawn from there toward the body over `length`). Verified against the
+stock `Conn_01x01`: `(pin … (at -5.08 0 0) (length 3.81))` with a body rectangle whose left
+edge is at `x = -1.27`, i.e. the stem runs `-5.08 → -1.27` and the connection point is the
+left tip `(-5.08, 0)`.
+
+**Symbol-local → sheet transform.** For a symbol placed at origin `(Ox, Oy)` with angle 0 and
+no mirror, KiCad maps a local point `(lx, ly)` to the sheet as
+
+```
+sheet_x = Ox + lx
+sheet_y = Oy − ly        (Y is flipped: symbol Y is up, sheet Y is down)
+```
+
+This was **verified against existing wiring** on the power sheet, not assumed: the placed
+`Conn_01x05` at `(176.53, 100.33)` angle 0 has pin 5 at local `(-5.08, -5.08)`, which maps to
+`(176.53 − 5.08, 100.33 − (−5.08)) = (171.45, 105.41)` — exactly the coordinate of the `GND`
+power symbol it connects to. Pins 1–4 likewise land on their wires/labels.
+
+**Placement.** `J1` is placed at `(Ox, Oy) = (152.4, 190.5)` (both multiples of 2.54). Pin
+*i* in the left column sits at local `(−25.4, 180.34 − (i−1)·2.54)`; the right column mirrors
+in `x` to `+25.4`. Applying the transform, every connection point lands on the 2.54 mm grid
+with `sheet_y ∈ [10.16, 373.38]` (all positive, fits A2). A `global_label` is anchored on
+each non-NC connection point, so the label attaches to the pin with no wire stub required —
+confirmed by the netlist (below).
+
+## 5. Design Decisions
+
+* **`global_label`, not local/hierarchical.** It is the design's dominant label type (452
+  occurrences) and merges nets across sheets by name, which is the whole point of exposing the
+  connector's nets. 125 of the connector's nets duly merge with existing nodes.
+* **Power pins `passive` by default.** Typing them `power_in` would make ERC demand a PWR_FLAG
+  on every rail, injecting noise into an additive phase. `passive` keeps the connector
+  ERC-neutral; `--power-type power_in` is offered for Phase 5, not baked in.
+* **NC pins typed `no_connect` and left unlabelled.** This keeps all 36 ECC/CB/2nd-rank/reserved
+  pins out of the ERC "unconnected" tally — they add **zero** violations, so the real connector
+  is cleaner than the placeholder it will replace.
+* **Library upgraded to a *copy* for validation.** `kicad-cli sym upgrade` writes to
+  `build/p2/`, leaving the committed `omi.kicad_sym` byte-identical to generator output, so the
+  "regenerate reproduces it" guarantee holds.
+* **Bug found and fixed during validation.** The first sheet emission omitted the closing `)`
+  of the `J1` `(symbol …)` node; KiCad silently dropped the malformed instance (0 J1 nodes in
+  the netlist, 129 dangling labels). Adding the paren fixed it — a good argument for gating on
+  the netlist, not just on "the file parses."
+
+## 6. Verification
+
+All gates run with KiCad 9.0.8 `kicad-cli` (format `20250114`).
+
+* **Symbol:** `sym upgrade` clean (no changes needed); `sym export svg` renders; `--verify`
+  reports **288/288 pins match the CSV exactly** (number + name + type); histogram
+  `{no_connect: 36, passive: 252}`.
+* **Sheet:** `sch erc` and `sch export netlist` both run; `sch export svg` renders the page.
+* **Netlist connectivity:** `J1` present with all 288 pins; sampled pins land on the exact
+  expected nets (79→A0, 2→GND, 59→VDD, 3→D0_DQ4, 142→VPP, 146→VREF, 141→SPD_SCL, 74→CK_t);
+  125 nets merge `J1` with other components; the 36 NC pins sit on auto `unconnected-(J1-…)`
+  nets (no error).
+* **Reproducibility:** regenerating to a temp path and diffing yields byte-identical files.
+
+**ERC delta: 131 → 135 (+4), fully attributable to the placement:**
+
+| Type | Baseline | After | Δ |
+| --- | --- | --- | --- |
+| pin_not_connected | 108 | 108 | 0 |
+| pin_not_driven | 16 | 16 | 0 |
+| power_pin_not_driven | 5 | 5 | 0 |
+| label_dangling | 2 | 2 | 0 |
+| **global_label_dangling** | 0 | **3** | **+3** |
+| **same_local_global_label** | 0 | **1** | **+1** |
+| **Total** | **131** | **135** | **+4** |
+
+The 3 new dangling globals are `ALERT_n`, `PARITY`, `VTT` — connector-side nets the CSV marks
+as host-supplied / not-enabled-in-v1, with no counterpart elsewhere yet. The 1
+same-local/global is `VREF` (root uses a *local* `VREF` label, the edge a *global* one). Both
+are cross-sheet reconciliation items owned by **Phase 3**; per scope they are reported, not
+fixed.
+
+## 7. Related Docs
+
+* `PHASE2_EDGE_SYMBOL_BRIEF.md` (working brief; intentionally untracked).
+* `baseline/phase1/PHASE1_BASELINE.md` — the 131-violation baseline this delta is measured against.
+* `tools/edge_symbol/README.md` — regeneration and validation commands.
+
+### Handoff to Phase 3
+* Replace the placeholder host connectors with wiring to `J1`.
+* Reconcile the connector-only nets (`ALERT_n`, `PARITY`, `VTT`) and the `VREF` local/global
+  clash (the ~4% name mismatches).
+* Add root hierarchy / sheet-pins if cross-sheet structure is formalised.
+* Resolve the pre-existing "schematic has annotation errors" warning.
+* ERC clean-up to zero/justified is Phase 5.

--- a/tools/edge_symbol/README.md
+++ b/tools/edge_symbol/README.md
@@ -1,0 +1,66 @@
+# `gen_edge_symbol.py` — 288-pin DDR4 UDIMM edge-connector generator
+
+`gen_edge_symbol.py` turns the keystone pinmap into the KiCad artifacts for the UDIMM
+edge connector. It is **standard-library-only Python 3** (no pip dependencies) and is
+fully deterministic: the same CSV always produces byte-identical output.
+
+## What it reads
+
+```
+design/connector/ddr4_udimm_288_pinmap.csv     # header: pin,symbol,omi_net,group,notes
+```
+
+This CSV is the **single source of truth** and is never modified by the generator.
+
+## What it writes
+
+| Output | Path (default) | Notes |
+| --- | --- | --- |
+| Symbol library | `design/power/omi_v1_power/omi.kicad_sym` | one symbol, `DDR4_UDIMM_288_Edge`, 288 pins |
+| Populated edge sheet | `design/power/omi_v1_power/udimm-edge-interface.kicad_sch` | one `J1` instance + `global_label` per non-NC pin |
+
+The library is registered in `design/power/omi_v1_power/sym-lib-table` under the nickname
+`omi`, so the symbol's `lib_id` is `omi:DDR4_UDIMM_288_Edge`.
+
+## CSV → symbol mapping
+
+* **pin number** ← CSV `pin`
+* **pin name** ← CSV `symbol` (the JEDEC / functional name shown on the body)
+* **electrical type**:
+  * `no_connect` when `omi_net == "NC"` (ECC/CB lanes, 2nd-rank, reserved — kept out of the
+    ERC "unconnected" tally by design);
+  * `passive` otherwise — **including power/ground by default**. Power pins can be promoted to
+    `power_in` with `--power-type power_in`, but that requires PWR_FLAGs to satisfy ERC and is a
+    Phase-5 decision, so `passive` is the default to keep this additive phase ERC-neutral.
+
+Net labels use **`global_label`**, the dominant label type in this design, so the `omi_net`
+names merge across sheets automatically. NC pins are left unconnected (their `no_connect`
+type makes that ERC-clean); they are never labelled with a signal net.
+
+## Regenerate
+
+```powershell
+python tools\edge_symbol\gen_edge_symbol.py
+```
+
+Useful flags:
+
+| Flag | Effect |
+| --- | --- |
+| `--no-sheet` | emit only the symbol library (defer placement) |
+| `--power-type power_in` | type POWER-group pins `power_in` instead of `passive` (needs PWR_FLAGs; Phase 5) |
+| `--verify` | re-parse `omi.kicad_sym` and assert 288 pins whose number+name+type match the CSV exactly |
+| `--csv / --out-sym / --out-sheet` | override input/output paths |
+
+## Validate (KiCad 9.0 `kicad-cli`)
+
+```powershell
+$bin = "$env:LOCALAPPDATA\Programs\KiCad\9.0\bin\kicad-cli.exe"
+& $bin sym upgrade -o build\p2\omi_upgraded.kicad_sym design\power\omi_v1_power\omi.kicad_sym
+& $bin sym export svg -o build\p2 design\power\omi_v1_power\omi.kicad_sym
+python tools\edge_symbol\gen_edge_symbol.py --verify
+& $bin sch erc --severity-all --format json -o build\p2\erc_after.json design\power\omi_v1_power\omi_v1_power.kicad_sch
+& $bin sch export netlist --format kicadxml -o build\p2\netlist_after.xml design\power\omi_v1_power\omi_v1_power.kicad_sch
+```
+
+Use the **KiCad 9.0** `kicad-cli` (schematic format `20250114`), not 10.x.

--- a/tools/edge_symbol/gen_edge_symbol.py
+++ b/tools/edge_symbol/gen_edge_symbol.py
@@ -44,8 +44,8 @@ Determinism: every UUID is derived with ``uuid.uuid5`` from a fixed namespace, s
 the generator twice on the same CSV produces byte-identical output (no timestamps, no RNG).
 
 Validation is layered: this script self-checks the in-memory model, the caller round-trips
-``omi.kicad_sym`` through ``kicad-cli sym upgrade`` + ``sym export svg``, and the ``verify``
-sub-command re-parses the emitted symbol and diffs every pin number+name against the CSV.
+``omi.kicad_sym`` through ``kicad-cli sym upgrade`` + ``sym export svg``, and the ``--verify``
+flag re-parses the emitted symbol and diffs every pin number+name against the CSV.
 """
 
 from __future__ import annotations

--- a/tools/edge_symbol/gen_edge_symbol.py
+++ b/tools/edge_symbol/gen_edge_symbol.py
@@ -1,0 +1,558 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2026 The Open Memory Initiative (OMI) contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Generate a 288-pin DDR4 UDIMM edge-connector KiCad 9 symbol from the keystone pinmap.
+
+This is the OMI v1 *Phase 2* generator. It reads the single source of truth
+
+    design/connector/ddr4_udimm_288_pinmap.csv   (header: pin,symbol,omi_net,group,notes)
+
+and emits, deterministically and with **standard library only**:
+
+  1. a KiCad 9.0 symbol library (``omi.kicad_sym``) holding one symbol,
+     ``DDR4_UDIMM_288_Edge``, with all 288 pins; and
+  2. (optionally) a populated copy of the edge sheet ``udimm-edge-interface.kicad_sch``
+     placing one instance of that symbol (ref ``J1``) and attaching a ``global_label``
+     (the dominant label type in this design) carrying the CSV ``omi_net`` to every
+     non-NC pin, so the names merge across sheets.
+
+CSV -> symbol pin mapping (CSV is authoritative):
+  * pin number   <- CSV ``pin``
+  * pin name     <- CSV ``symbol``   (the functional / JEDEC name shown on the body)
+  * electrical type:
+        - ``no_connect``  when ``omi_net == "NC"``  (ECC / CB / 2nd-rank / reserved pins)
+        - otherwise ``passive``     (signals AND power/ground by default)
+
+  Power pins default to ``passive`` on purpose: typing them ``power_in`` would require
+  PWR_FLAGs to keep ERC quiet, which is a Phase-5 decision. Pass ``--power-type power_in``
+  to opt into the stricter typing; the default keeps this additive phase ERC-neutral.
+
+Geometry (all millimetres, 100-mil / 2.54 mm pitch):
+  Two columns of 144 pins. Pins 1..144 exit left, 145..288 exit right. A pin's ``(at x y)``
+  IS its electrical connection point; with the symbol placed at angle 0 (no mirror) the
+  sheet coordinate of a pin is ``(Ox + x, Oy - y)`` (KiCad's symbol->sheet Y flip, verified
+  against the existing Conn_01x05/GND wiring on the power sheet). Each non-NC pin therefore
+  gets a global_label anchored exactly on that point -- no wires required.
+
+Determinism: every UUID is derived with ``uuid.uuid5`` from a fixed namespace, so running
+the generator twice on the same CSV produces byte-identical output (no timestamps, no RNG).
+
+Validation is layered: this script self-checks the in-memory model, the caller round-trips
+``omi.kicad_sym`` through ``kicad-cli sym upgrade`` + ``sym export svg``, and the ``verify``
+sub-command re-parses the emitted symbol and diffs every pin number+name against the CSV.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+import uuid
+from pathlib import Path
+
+# --------------------------------------------------------------------------------------
+# Fixed identifiers from the existing design (read-only facts, captured during inspection)
+# --------------------------------------------------------------------------------------
+PROJECT_NAME = "omi_v1_power"
+ROOT_SHEET_UUID = "464309c0-e3ad-4428-a43f-e1cf3b7a7d42"          # root .kicad_sch uuid
+EDGE_SHEET_NODE_UUID = "9986c6c0-2ac4-474e-a00a-d8203c8bf46f"     # (sheet ...) node in root
+EDGE_SHEET_FILE_UUID = "210817e1-752b-42f4-8fed-a870dd9e41c3"     # edge sheet's own uuid
+# Hierarchical instance path for a symbol living on the edge sub-sheet:
+EDGE_INSTANCE_PATH = f"/{ROOT_SHEET_UUID}/{EDGE_SHEET_NODE_UUID}"
+
+# Deterministic-UUID namespace (arbitrary fixed constant -> reproducible output).
+NS_UUID = uuid.UUID("b6e4f4a0-0c2e-5a7d-9f31-0a2b3c4d5e6f")
+
+# Symbol / library naming
+LIB_NICKNAME = "omi"
+SYMBOL_NAME = "DDR4_UDIMM_288_Edge"
+LIB_ID = f"{LIB_NICKNAME}:{SYMBOL_NAME}"
+REFERENCE_PREFIX = "J"
+PLACED_REFERENCE = "J1"
+
+# KiCad format tokens (captured from the stock 9.0 Connector library / project sheets)
+SYM_LIB_VERSION = 20241209
+SCH_VERSION = 20250114
+
+# Geometry
+PITCH = 2.54
+PIN_LENGTH = 5.08
+X_OUT = 25.4                 # |x| of a pin's connection point in symbol-local coords
+BODY_X = X_OUT - PIN_LENGTH  # 20.32 -> body rectangle half-width (pin meets body edge)
+COL_SIZE = 144
+TOP_Y = 71 * PITCH           # 180.34 -> y of the top pin (grid-aligned)
+PLACE_OX = 60 * PITCH        # 152.4  -> sheet placement origin X (grid-aligned)
+PLACE_OY = 75 * PITCH        # 190.5  -> sheet placement origin Y (keeps all y > 0)
+
+NC_TOKEN = "NC"              # a row is No-Connect iff omi_net == "NC"
+
+EXPECTED_PIN_COUNT = 288
+
+
+# --------------------------------------------------------------------------------------
+# Model
+# --------------------------------------------------------------------------------------
+class Pin:
+    """One physical edge-finger: number, displayed name, net, and derived electrical type."""
+
+    __slots__ = ("number", "name", "net", "group", "notes", "etype", "is_nc")
+
+    def __init__(self, number: int, name: str, net: str, group: str, notes: str,
+                 power_type: str):
+        self.number = number
+        self.name = name
+        self.net = net
+        self.group = group
+        self.notes = notes
+        self.is_nc = (net == NC_TOKEN)
+        if self.is_nc:
+            self.etype = "no_connect"
+        elif group == "POWER":
+            self.etype = power_type        # "passive" (default) or "power_in"
+        else:
+            self.etype = "passive"
+
+
+def det_uuid(*parts: str) -> str:
+    """Stable UUID from a fixed namespace and a dotted name -> reproducible files."""
+    return str(uuid.uuid5(NS_UUID, ".".join(parts)))
+
+
+def esc(s: str) -> str:
+    r"""Escape a string for a KiCad s-expression double-quoted token (\\ and \")."""
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def read_pinmap(csv_path: Path, power_type: str) -> list[Pin]:
+    """Parse and validate the pinmap CSV; return 288 Pins ordered by ascending pin number.
+
+    Raises ValueError on any schema violation so a bad CSV can never yield a bad symbol.
+    """
+    with csv_path.open(newline="", encoding="utf-8-sig") as fh:
+        reader = csv.DictReader(fh)
+        expected_header = ["pin", "symbol", "omi_net", "group", "notes"]
+        if reader.fieldnames != expected_header:
+            raise ValueError(
+                f"unexpected CSV header {reader.fieldnames!r}; expected {expected_header!r}")
+        pins: list[Pin] = []
+        seen: set[int] = set()
+        for lineno, row in enumerate(reader, start=2):
+            raw_pin = (row["pin"] or "").strip()
+            if raw_pin == "":
+                raise ValueError(f"line {lineno}: empty pin number")
+            number = int(raw_pin)
+            if number in seen:
+                raise ValueError(f"line {lineno}: duplicate pin number {number}")
+            seen.add(number)
+            name = (row["symbol"] or "").strip()
+            net = (row["omi_net"] or "").strip()
+            group = (row["group"] or "").strip()
+            notes = (row["notes"] or "").strip()
+            if name == "":
+                raise ValueError(f"line {lineno}: empty symbol/name for pin {number}")
+            if net == "":
+                raise ValueError(f"line {lineno}: empty omi_net for pin {number}")
+            pins.append(Pin(number, name, net, group, notes, power_type))
+
+    if len(pins) != EXPECTED_PIN_COUNT:
+        raise ValueError(f"expected {EXPECTED_PIN_COUNT} data rows, found {len(pins)}")
+    pins.sort(key=lambda p: p.number)
+    if [p.number for p in pins] != list(range(1, EXPECTED_PIN_COUNT + 1)):
+        raise ValueError("pin numbers are not the contiguous range 1..288")
+    return pins
+
+
+# --------------------------------------------------------------------------------------
+# Geometry helpers
+# --------------------------------------------------------------------------------------
+def fmt(n: float) -> str:
+    """Format a millimetre coordinate the way KiCad does (trim trailing zeros)."""
+    s = f"{n:.4f}".rstrip("0").rstrip(".")
+    return "0" if s in ("", "-0") else s
+
+
+def local_pin_geometry(pin_number: int):
+    """Return (local_x, local_y, pin_angle, column) for a pin in the symbol's own frame."""
+    if pin_number <= COL_SIZE:                      # left column, exits left, body to right
+        row = pin_number - 1
+        return (-X_OUT, TOP_Y - row * PITCH, 0, "L")
+    row = pin_number - COL_SIZE - 1                  # right column, exits right, body to left
+    return (X_OUT, TOP_Y - row * PITCH, 180, "R")
+
+
+def sheet_point(local_x: float, local_y: float):
+    """Symbol-local -> edge-sheet coordinate for the J1 placement (angle 0, no mirror)."""
+    return (PLACE_OX + local_x, PLACE_OY - local_y)
+
+
+# --------------------------------------------------------------------------------------
+# Emitters
+# --------------------------------------------------------------------------------------
+def _effects(*extra: str, hide: bool = False) -> list[str]:
+    lines = ["(effects", "\t(font", "\t\t(size 1.27 1.27)", "\t)"]
+    for e in extra:
+        lines.append(f"\t{e}")
+    if hide:
+        lines.append("\t(hide yes)")
+    lines.append(")")
+    return lines
+
+
+def _indent(block: list[str], tabs: int) -> list[str]:
+    pad = "\t" * tabs
+    return [pad + ln for ln in block]
+
+
+def emit_symbol_body(pins: list[Pin]) -> list[str]:
+    """The inner ``(symbol "..._1_1" ...)`` graphic unit: body rectangle + 288 pins."""
+    out: list[str] = []
+    out.append(f'(symbol "{SYMBOL_NAME}_1_1"')
+    top = TOP_Y + PITCH
+    bot = TOP_Y - (COL_SIZE - 1) * PITCH - PITCH
+    out.append("\t(rectangle")
+    out.append(f"\t\t(start {fmt(-BODY_X)} {fmt(top)})")
+    out.append(f"\t\t(end {fmt(BODY_X)} {fmt(bot)})")
+    out.append("\t\t(stroke")
+    out.append("\t\t\t(width 0.254)")
+    out.append("\t\t\t(type default)")
+    out.append("\t\t)")
+    out.append("\t\t(fill")
+    out.append("\t\t\t(type background)")
+    out.append("\t\t)")
+    out.append("\t)")
+    for p in pins:
+        lx, ly, ang, _col = local_pin_geometry(p.number)
+        out.append(f"\t(pin {p.etype} line")
+        out.append(f"\t\t(at {fmt(lx)} {fmt(ly)} {ang})")
+        out.append(f"\t\t(length {fmt(PIN_LENGTH)})")
+        out.append(f'\t\t(name "{esc(p.name)}"')
+        out.extend(_indent(_effects(), 3))
+        out.append("\t\t)")
+        out.append(f'\t\t(number "{p.number}"')
+        out.extend(_indent(_effects(), 3))
+        out.append("\t\t)")
+        out.append("\t)")
+    out.append(")")
+    return out
+
+
+def emit_symbol_definition() -> list[str]:
+    """The library ``(symbol "DDR4_UDIMM_288_Edge" ...)`` header (properties + pin_names)."""
+    out: list[str] = []
+    out.append(f'(symbol "{SYMBOL_NAME}"')
+    out.append("\t(pin_names")
+    out.append("\t\t(offset 1.016)")
+    out.append("\t)")
+    out.append("\t(exclude_from_sim no)")
+    out.append("\t(in_bom yes)")
+    out.append("\t(on_board yes)")
+    props = [
+        ("Reference", REFERENCE_PREFIX, f"0 {fmt(TOP_Y + 3 * PITCH)} 0", False),
+        ("Value", SYMBOL_NAME, f"0 {fmt(TOP_Y - (COL_SIZE - 1) * PITCH - 3 * PITCH)} 0", False),
+        ("Footprint", "", "0 0 0", True),
+        ("Datasheet", "~", "0 0 0", True),
+        ("Description",
+         "DDR4 UDIMM 288-pin edge connector; generated from ddr4_udimm_288_pinmap.csv",
+         "0 0 0", True),
+        ("ki_keywords", "DDR4 UDIMM 288 edge connector DIMM", "0 0 0", True),
+    ]
+    for name, value, at, hide in props:
+        out.append(f'\t(property "{name}" "{esc(value)}"')
+        out.append(f"\t\t(at {at})")
+        out.extend(_indent(_effects(hide=hide), 2))
+        out.append("\t)")
+    return out
+
+
+def emit_library(pins: list[Pin]) -> str:
+    out: list[str] = []
+    out.append("(kicad_symbol_lib")
+    out.append(f"\t(version {SYM_LIB_VERSION})")
+    out.append('\t(generator "kicad_symbol_editor")')
+    out.append('\t(generator_version "9.0")')
+    for ln in emit_symbol_definition():
+        out.append("\t" + ln)
+    for ln in emit_symbol_body(pins):
+        out.append("\t\t" + ln)
+    out.append("\t\t(embedded_fonts no)")
+    out.append("\t)")
+    out.append(")")
+    return "\n".join(out) + "\n"
+
+
+def emit_global_label(net: str, x: float, y: float, column: str, uid: str) -> list[str]:
+    """One global_label anchored on a pin's connection point (matches the BA0 convention)."""
+    if column == "L":           # pin exits left -> label reads leftwards
+        angle, justify, ir_x = 180, "right", x - 2.54
+    else:                       # pin exits right -> label reads rightwards
+        angle, justify, ir_x = 0, "left", x + 2.54
+    out = [
+        f'(global_label "{esc(net)}"',
+        "\t(shape input)",
+        f"\t(at {fmt(x)} {fmt(y)} {angle})",
+        "\t(fields_autoplaced yes)",
+        "\t(effects",
+        "\t\t(font",
+        "\t\t\t(size 1.27 1.27)",
+        "\t\t)",
+        f"\t\t(justify {justify})",
+        "\t)",
+        f'\t(uuid "{uid}")',
+        '\t(property "Intersheetrefs" "${INTERSHEET_REFS}"',
+        f"\t\t(at {fmt(ir_x)} {fmt(y)} 0)",
+        "\t\t(effects",
+        "\t\t\t(font",
+        "\t\t\t\t(size 1.27 1.27)",
+        "\t\t\t)",
+        f"\t\t\t(justify {justify})",
+        "\t\t\t(hide yes)",
+        "\t\t)",
+        "\t)",
+        ")",
+    ]
+    return out
+
+
+def emit_placed_symbol(pins: list[Pin]) -> list[str]:
+    """The ``(symbol (lib_id omi:...) ...)`` instance for J1 on the edge sheet."""
+    out: list[str] = []
+    out.append("(symbol")
+    out.append(f'\t(lib_id "{LIB_ID}")')
+    out.append(f"\t(at {fmt(PLACE_OX)} {fmt(PLACE_OY)} 0)")
+    out.append("\t(unit 1)")
+    out.append("\t(exclude_from_sim no)")
+    out.append("\t(in_bom yes)")
+    out.append("\t(on_board yes)")
+    out.append("\t(dnp no)")
+    out.append(f'\t(uuid "{det_uuid("placed", "j1")}")')
+    ref_at = f"{fmt(PLACE_OX - BODY_X)} {fmt(PLACE_OY - TOP_Y - 3 * PITCH)} 0"
+    val_at = f"{fmt(PLACE_OX - BODY_X)} {fmt(PLACE_OY - (TOP_Y - (COL_SIZE - 1) * PITCH) + 3 * PITCH)} 0"
+    placed_props = [
+        ("Reference", PLACED_REFERENCE, ref_at, False),
+        ("Value", SYMBOL_NAME, val_at, False),
+        ("Footprint", "", f"{fmt(PLACE_OX)} {fmt(PLACE_OY)} 0", True),
+        ("Datasheet", "~", f"{fmt(PLACE_OX)} {fmt(PLACE_OY)} 0", True),
+    ]
+    for name, value, at, hide in placed_props:
+        out.append(f'\t(property "{name}" "{esc(value)}"')
+        out.append(f"\t\t(at {at})")
+        out.extend(_indent(_effects(hide=hide), 2))
+        out.append("\t)")
+    for p in pins:
+        out.append(f'\t(pin "{p.number}"')
+        out.append(f'\t\t(uuid "{det_uuid("placed", "j1", "pin", str(p.number))}")')
+        out.append("\t)")
+    out.append("\t(instances")
+    out.append(f'\t\t(project "{PROJECT_NAME}"')
+    out.append(f'\t\t\t(path "{EDGE_INSTANCE_PATH}"')
+    out.append(f'\t\t\t\t(reference "{PLACED_REFERENCE}")')
+    out.append("\t\t\t\t(unit 1)")
+    out.append("\t\t\t)")
+    out.append("\t\t)")
+    out.append("\t)")
+    out.append(")")                 # close the (symbol ...) instance node
+    return out
+
+
+def emit_sheet(pins: list[Pin]) -> str:
+    """The fully-populated ``udimm-edge-interface.kicad_sch`` (header + lib_symbols + content)."""
+    out: list[str] = []
+    out.append("(kicad_sch")
+    out.append(f"\t(version {SCH_VERSION})")
+    out.append('\t(generator "eeschema")')
+    out.append('\t(generator_version "9.0")')
+    out.append(f'\t(uuid "{EDGE_SHEET_FILE_UUID}")')
+    out.append('\t(paper "A2")')
+
+    # Embedded library symbol: same body, but the wrapper is named with the lib_id.
+    out.append("\t(lib_symbols")
+    out.append(f'\t\t(symbol "{LIB_ID}"')
+    for ln in emit_symbol_definition()[1:]:          # drop the '(symbol "NAME"' opener
+        out.append("\t\t\t" + ln)
+    for ln in emit_symbol_body(pins):
+        out.append("\t\t\t\t" + ln)
+    out.append("\t\t\t\t(embedded_fonts no)")
+    out.append("\t\t)")
+    out.append("\t)")
+
+    # Global labels for every non-NC pin, anchored exactly on the pin connection point.
+    for p in pins:
+        if p.is_nc:
+            continue
+        lx, ly, _ang, col = local_pin_geometry(p.number)
+        sx, sy = sheet_point(lx, ly)
+        uid = det_uuid("label", str(p.number))
+        for ln in emit_global_label(p.net, sx, sy, col, uid):
+            out.append("\t" + ln)
+
+    # The J1 instance.
+    for ln in emit_placed_symbol(pins):
+        out.append("\t" + ln)
+
+    out.append("\t(embedded_fonts no)")
+    out.append(")")
+    return "\n".join(out) + "\n"
+
+
+# --------------------------------------------------------------------------------------
+# Verify: re-parse an emitted .kicad_sym and diff against the CSV
+# --------------------------------------------------------------------------------------
+def _tokenize(text: str):
+    return re.findall(r'"(?:[^"\\]|\\.)*"|\(|\)|[^\s()]+', text)
+
+
+def _parse(tokens):
+    """Recursive-descent s-expression -> nested lists; strings keep a leading '"' marker."""
+    it = iter(tokens)
+
+    def build():
+        node = []
+        for tok in it:
+            if tok == "(":
+                node.append(build())
+            elif tok == ")":
+                return node
+            else:
+                node.append(tok)
+        return node
+
+    for tok in it:
+        if tok == "(":
+            return build()
+    return []
+
+
+def _unq(tok: str) -> str:
+    if tok.startswith('"') and tok.endswith('"'):
+        return tok[1:-1].replace('\\"', '"').replace("\\\\", "\\")
+    return tok
+
+
+def _walk_pins(node, found):
+    if not isinstance(node, list) or not node:
+        return
+    if node[0] == "pin" and len(node) >= 3 and isinstance(node[1], str):
+        etype = node[1]
+        name = number = None
+        for child in node:
+            if isinstance(child, list) and child:
+                if child[0] == "name":
+                    name = _unq(child[1])
+                elif child[0] == "number":
+                    number = _unq(child[1])
+        if name is not None and number is not None:
+            found.append((number, name, etype))
+    for child in node:
+        if isinstance(child, list):
+            _walk_pins(child, found)
+
+
+def verify(sym_path: Path, csv_path: Path) -> int:
+    """Assert the emitted symbol has 288 pins exactly matching the CSV (number+name+type)."""
+    pins = read_pinmap(csv_path, power_type="passive")
+    expected_by_number = {str(p.number): p for p in pins}
+    text = sym_path.read_text(encoding="utf-8")
+    root = _parse(_tokenize(text))
+    found: list[tuple[str, str, str]] = []
+    _walk_pins(root, found)
+
+    errors: list[str] = []
+    if len(found) != EXPECTED_PIN_COUNT:
+        errors.append(f"pin count is {len(found)}, expected {EXPECTED_PIN_COUNT}")
+
+    seen_numbers = set()
+    for number, name, etype in found:
+        seen_numbers.add(number)
+        exp = expected_by_number.get(number)
+        if exp is None:
+            errors.append(f"pin {number}: not in CSV")
+            continue
+        if name != exp.name:
+            errors.append(f"pin {number}: name {name!r} != CSV {exp.name!r}")
+        if etype != exp.etype:
+            errors.append(f"pin {number}: type {etype!r} != expected {exp.etype!r}")
+    missing = set(expected_by_number) - seen_numbers
+    for number in sorted(missing, key=int):
+        errors.append(f"pin {number}: missing from symbol")
+
+    hist: dict[str, int] = {}
+    for _n, _nm, etype in found:
+        hist[etype] = hist.get(etype, 0) + 1
+
+    if errors:
+        print("VERIFY: FAIL")
+        for e in errors[:50]:
+            print("  - " + e)
+        if len(errors) > 50:
+            print(f"  ... and {len(errors) - 50} more")
+        return 1
+    print("VERIFY: PASS")
+    print(f"  pins matched exactly against CSV: {len(found)}/{EXPECTED_PIN_COUNT}")
+    print(f"  electrical-type histogram: {dict(sorted(hist.items()))}")
+    return 0
+
+
+# --------------------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------------------
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def main(argv: list[str]) -> int:
+    root = repo_root()
+    default_csv = root / "design" / "connector" / "ddr4_udimm_288_pinmap.csv"
+    proj_dir = root / "design" / "power" / "omi_v1_power"
+    default_sym = proj_dir / "omi.kicad_sym"
+    default_sheet = proj_dir / "udimm-edge-interface.kicad_sch"
+
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--csv", type=Path, default=default_csv)
+    ap.add_argument("--out-sym", type=Path, default=default_sym)
+    ap.add_argument("--out-sheet", type=Path, default=default_sheet)
+    ap.add_argument("--power-type", choices=["passive", "power_in"], default="passive",
+                    help="electrical type for POWER-group pins (default: passive; "
+                         "power_in is the stricter Phase-5 option and needs PWR_FLAGs)")
+    ap.add_argument("--no-sheet", action="store_true",
+                    help="emit only the symbol library (defer placement)")
+    ap.add_argument("--verify", action="store_true",
+                    help="instead of generating, re-parse --out-sym and diff against the CSV")
+    args = ap.parse_args(argv)
+
+    if args.verify:
+        return verify(args.out_sym, args.csv)
+
+    pins = read_pinmap(args.csv, args.power_type)
+
+    nc = sum(1 for p in pins if p.is_nc)
+    power = sum(1 for p in pins if (not p.is_nc) and p.group == "POWER")
+    signal = len(pins) - nc - power
+    hist: dict[str, int] = {}
+    for p in pins:
+        hist[p.etype] = hist.get(p.etype, 0) + 1
+
+    args.out_sym.parent.mkdir(parents=True, exist_ok=True)
+    args.out_sym.write_text(emit_library(pins), encoding="utf-8")
+    print(f"wrote symbol library: {args.out_sym}")
+    print(f"  pins={len(pins)}  NC={nc}  power={power}  signal={signal}")
+    print(f"  electrical-type histogram: {dict(sorted(hist.items()))}")
+
+    if not args.no_sheet:
+        args.out_sheet.write_text(emit_sheet(pins), encoding="utf-8")
+        labelled = sum(1 for p in pins if not p.is_nc)
+        print(f"wrote populated edge sheet: {args.out_sheet}")
+        print(f"  J1 placed; {labelled} global_labels; {nc} NC pins left unconnected")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/edge_symbol/gen_edge_symbol.py
+++ b/tools/edge_symbol/gen_edge_symbol.py
@@ -454,9 +454,9 @@ def _walk_pins(node, found):
             _walk_pins(child, found)
 
 
-def verify(sym_path: Path, csv_path: Path) -> int:
+def verify(sym_path: Path, csv_path: Path, power_type: str) -> int:
     """Assert the emitted symbol has 288 pins exactly matching the CSV (number+name+type)."""
-    pins = read_pinmap(csv_path, power_type="passive")
+    pins = read_pinmap(csv_path, power_type=power_type)
     expected_by_number = {str(p.number): p for p in pins}
     text = sym_path.read_text(encoding="utf-8")
     root = _parse(_tokenize(text))

--- a/tools/edge_symbol/gen_edge_symbol.py
+++ b/tools/edge_symbol/gen_edge_symbol.py
@@ -528,7 +528,7 @@ def main(argv: list[str]) -> int:
     args = ap.parse_args(argv)
 
     if args.verify:
-        return verify(args.out_sym, args.csv)
+        return verify(args.out_sym, args.csv, args.power_type)
 
     pins = read_pinmap(args.csv, args.power_type)
 


### PR DESCRIPTION
## Phase 2 — 288-pin DDR4 UDIMM edge-connector symbol (generated from CSV)

Generates the edge connector from the keystone pinmap and places it on the previously-empty
edge sheet. **Additive phase** — no ERC fixing, no placeholder removal, no cross-sheet surgery
(those are P3/P5).

### What was generated
- **`tools/edge_symbol/gen_edge_symbol.py`** — stdlib-only, Apache-2.0, deterministic
  (`uuid5`, no RNG/timestamps → byte-identical regeneration). Reads
  `design/connector/ddr4_udimm_288_pinmap.csv` (single source of truth, unmodified).
- **`design/power/omi_v1_power/omi.kicad_sym`** — one symbol `DDR4_UDIMM_288_Edge`, 288 pins,
  two 144-pin columns on 100-mil pitch.
- **`design/power/omi_v1_power/sym-lib-table`** — registers the lib as nickname `omi`.
- **`design/power/omi_v1_power/udimm-edge-interface.kicad_sch`** — the **only** existing file
  edited: one `J1` instance + a `global_label` (the design's dominant label type) on every
  non-NC pin.

### Mapping
`pin#←pin`, `name←symbol`, `type = no_connect` iff `omi_net==NC` else `passive`
(power defaults to `passive`; `--power-type power_in` is the P5 option, not baked in).
**Histogram: 36 `no_connect`, 252 `passive`.**

### Validation (kicad-cli 9.0.8, format 20250114)
- `sym upgrade` clean · `sym export svg` renders · `--verify` → **288/288 pins match the CSV
  exactly** (number+name+type).
- Edge sheet: ERC + netlist run; page renders.
- Netlist: `J1` present with all 288 pins on the **expected** nets (79→A0, 2→GND, 59→VDD,
  3→D0_DQ4, 142→VPP, 146→VREF, 141→SPD_SCL, 74→CK_t); **125 nets merge** `J1` with other
  components; the 36 NC pins sit on auto `unconnected-(J1-…)` nets (zero ERC cost).
- Reproducibility: regenerate + diff → byte-identical.

### ERC delta: **131 → 135 (+4)**, fully attributable to placement
| Type | Baseline | After | Δ |
| --- | --- | --- | --- |
| pin_not_connected | 108 | 108 | 0 |
| pin_not_driven | 16 | 16 | 0 |
| power_pin_not_driven | 5 | 5 | 0 |
| label_dangling | 2 | 2 | 0 |
| global_label_dangling | 0 | 3 | **+3** |
| same_local_global_label | 0 | 1 | **+1** |

- **+3 dangling**: `ALERT_n`, `PARITY`, `VTT` — connector-side nets (host-supplied /
  not-enabled-in-v1) with no counterpart elsewhere yet.
- **+1 same-local/global**: `VREF` (root uses a *local* label, edge a *global* one).

Both are **Phase-3** cross-sheet reconciliation — reported, not fixed.

### For Phase 3
Replace placeholder host connectors → wire to `J1`; reconcile `ALERT_n`/`PARITY`/`VTT` and the
`VREF` local/global clash (the ~4% name mismatches); add root hierarchy/sheet-pins if needed;
clear the pre-existing "schematic has annotation errors" warning. ERC→0 is Phase 5.
